### PR TITLE
Updating Security Policy section in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,29 +135,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-The Centers for Medicare & Medicaid Services is committed to ensuring the
-security of the American public by protecting their information from
-unwarranted disclosure. We want security researchers to feel comfortable
-reporting vulnerabilities they have discovered so we can fix them and keep our
-users safe. We developed our disclosure policy to reflect our values and uphold
-our sense of responsibility to security researchers who share their expertise
-with us in good faith.
-
-_Submit a vulnerability:_ Unfortunately, we cannot accept secure submissions via
+*Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
 [https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 
-Review the HHS Disclosure Policy and websites in scope:
-[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
-
-This policy describes _what systems and types of research_ are covered under this
-policy, _how to send_ us vulnerability reports, and _how long_ we ask security
-researchers to wait before publicly disclosing vulnerabilities.
-
-If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov](mailto:csirc@hhs.gov).
+For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Public domain
 

--- a/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -96,29 +96,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-The Centers for Medicare & Medicaid Services is committed to ensuring the
-security of the American public by protecting their information from
-unwarranted disclosure. We want security researchers to feel comfortable
-reporting vulnerabilities they have discovered so we can fix them and keep our
-users safe. We developed our disclosure policy to reflect our values and uphold
-our sense of responsibility to security researchers who share their expertise
-with us in good faith.
-
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
 [https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 
-Review the HHS Disclosure Policy and websites in scope:
-[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
-
-This policy describes *what systems and types of research* are covered under this
-policy, *how to send* us vulnerability reports, and *how long* we ask security
-researchers to wait before publicly disclosing vulnerabilities.
-
-If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov](mailto:csirc@hhs.gov).
+For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Public domain
 

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -152,13 +152,6 @@ Policy](https://github.com/CMSGov/cms-open-source-policy). If you have any
 questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
-The Centers for Medicare & Medicaid Services is committed to ensuring the
-security of the American public by protecting their information from
-unwarranted disclosure. We want security researchers to feel comfortable
-reporting vulnerabilities they have discovered so we can fix them and keep our
-users safe. We developed our disclosure policy to reflect our values and uphold
-our sense of responsibility to security researchers who share their expertise
-with us in good faith.
 
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
@@ -166,15 +159,7 @@ email or via GitHub Issues. Please use our website to submit vulnerabilities at
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 
-Review the HHS Disclosure Policy and websites in scope:
-[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
-
-This policy describes *what systems and types of research* are covered under this
-policy, *how to send* us vulnerability reports, and *how long* we ask security
-researchers to wait before publicly disclosing vulnerabilities.
-
-If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov](mailto:csirc@hhs.gov).
+For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Public domain
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -181,29 +181,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-The Centers for Medicare & Medicaid Services is committed to ensuring the
-security of the American public by protecting their information from
-unwarranted disclosure. We want security researchers to feel comfortable
-reporting vulnerabilities they have discovered so we can fix them and keep our
-users safe. We developed our disclosure policy to reflect our values and uphold
-our sense of responsibility to security researchers who share their expertise
-with us in good faith.
-
-_Submit a vulnerability:_ Unfortunately, we cannot accept secure submissions via
+*Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
 [https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 
-Review the HHS Disclosure Policy and websites in scope:
-[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
-
-This policy describes _what systems and types of research_ are covered under this
-policy, _how to send_ us vulnerability reports, and _how long_ we ask security
-researchers to wait before publicly disclosing vulnerabilities.
-
-If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov](mailto:csirc@hhs.gov).
+For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Public domain
 

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -180,29 +180,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-The Centers for Medicare & Medicaid Services is committed to ensuring the
-security of the American public by protecting their information from
-unwarranted disclosure. We want security researchers to feel comfortable
-reporting vulnerabilities they have discovered so we can fix them and keep our
-users safe. We developed our disclosure policy to reflect our values and uphold
-our sense of responsibility to security researchers who share their expertise
-with us in good faith.
-
-_Submit a vulnerability:_ Unfortunately, we cannot accept secure submissions via
+*Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
 [https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
 HHS maintains an acknowledgements page to recognize your efforts on behalf of
 the American public, but you are also welcome to submit anonymously.
 
-Review the HHS Disclosure Policy and websites in scope:
-[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
-
-This policy describes _what systems and types of research_ are covered under this
-policy, _how to send_ us vulnerability reports, and _how long_ we ask security
-researchers to wait before publicly disclosing vulnerabilities.
-
-If you have other cybersecurity related questions, please contact us at
-[csirc@hhs.gov](mailto:csirc@hhs.gov).
+For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Public domain
 


### PR DESCRIPTION
## CONTRIBUTING.md updates

## Problem

Based on our discussions outbounding the DedupliFHIR repository, we decided to reduce the content in the Security and Responsible Disclosure policies section.

## Solution

Updated Security and Responsible Disclosure policies section to:
- Only include the vulnerability submission section
- Include a one-liner that points to the `SECURITY.md` file