### PR TITLE
Added CODE_OF_CONDUCT.md and COMMUNITY_GUIDELINES.md to Tier 3 + 4

### DIFF
--- a/tier3/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+++ b/tier3/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers at opensource@cms.hhs.gov.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+
+## Acknowledgements
+
+This CODE_OF_CONDUCT.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -27,11 +27,10 @@ When participating in {Project Name} open source community conversations and spa
   - your related organization (if applicable)
   - your pronouns
   - disclosure of any current or potential financial interest in this work
-  - your superpower, and how you hope to use it for DeDupliFHIR
+  - your superpower, and how you hope to use it for {Project Name}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
-<!-- TODO: Add if your repo has a community chat 
-- Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
+<!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
 - Be respectful.
 - Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.
 

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -1,0 +1,40 @@
+# {Project Name} Open Source Community Guidelines
+
+This document contains principles and guidelines for participating in the {Project Name} open source community.
+
+## Principles
+
+These principles guide our data, product, and process decisions, architecture, and approach.
+
+- Open means transparent and participatory.
+- We take a modular and modern approach to software development.
+- We build open-source software and open-source process.
+- We value ease of implementation.
+- Fostering community includes building capacity and making our software and processes accessible to participants with diverse backgrounds and skillsets.
+- Data (and data science) is as important as software and process. We build open data sets where possible.
+- We strive for transparency for algorithms and places we might be introducing bias.
+- We prioritize data sets that address community vulnerabilities for programs in Justice40.
+
+## Community Guidelines
+
+All community members are expected to adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
+
+When participating in {Project Name} open source community conversations and spaces, we ask individuals to follow the following guidelines:
+
+- When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
+  - your related organization (if applicable)
+  - your pronouns
+  - disclosure of any current or potential financial interest in this work
+  - your superpower, and how you hope to use it for DeDupliFHIR
+- Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
+- Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
+<!-- TODO: Add if your repo has a community chat 
+- Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
+- Be respectful.
+- Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.
+
+## Acknowledgements
+
+This COMMUNITY_GUIDELINES.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.

--- a/tier4/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+++ b/tier4/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers at opensource@cms.hhs.gov.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+
+## Acknowledgements
+
+This CODE_OF_CONDUCT.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -27,11 +27,10 @@ When participating in {Project Name} open source community conversations and spa
   - your related organization (if applicable)
   - your pronouns
   - disclosure of any current or potential financial interest in this work
-  - your superpower, and how you hope to use it for DeDupliFHIR
+  - your superpower, and how you hope to use it for {Project Name}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
-<!-- TODO: Add if your repo has a community chat 
-- Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
+<!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
 - Be respectful.
 - Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.
 

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -1,0 +1,40 @@
+# {Project Name} Open Source Community Guidelines
+
+This document contains principles and guidelines for participating in the {Project Name} open source community.
+
+## Principles
+
+These principles guide our data, product, and process decisions, architecture, and approach.
+
+- Open means transparent and participatory.
+- We take a modular and modern approach to software development.
+- We build open-source software and open-source process.
+- We value ease of implementation.
+- Fostering community includes building capacity and making our software and processes accessible to participants with diverse backgrounds and skillsets.
+- Data (and data science) is as important as software and process. We build open data sets where possible.
+- We strive for transparency for algorithms and places we might be introducing bias.
+- We prioritize data sets that address community vulnerabilities for programs in Justice40.
+
+## Community Guidelines
+
+All community members are expected to adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
+
+When participating in {Project Name} open source community conversations and spaces, we ask individuals to follow the following guidelines:
+
+- When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
+  - your related organization (if applicable)
+  - your pronouns
+  - disclosure of any current or potential financial interest in this work
+  - your superpower, and how you hope to use it for DeDupliFHIR
+- Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
+- Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
+<!-- TODO: Add if your repo has a community chat 
+- Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->
+- Be respectful.
+- Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.
+
+## Acknowledgements
+
+This COMMUNITY_GUIDELINES.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.


### PR DESCRIPTION
## Added CODE_OF_CONDUCT.md and COMMUNITY_GUIDELINES.md to Tiers 3 + 4

## Problem
Tier 3 & 4 projects require guidance around community governance however we were lacking these policies until now.

## Solution
We have created new `CODE_OF_CONDUCT.md` and `COMMUNITY_GUIDELINES`files based off the USDS Justice 40 project.`GOVERNANCE.md` point to these files.

## Result
When running this tool, it will generate these files for tiers 3 & 4 going forward.