### PR TITLE
Updated MAINTAINERS.md file for Tier 2 and Tier 3

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# Maintainers
+This is a list of maintainers for this project. See CODEOWNERS for list of reviewers for different parts of the codebase. Team members include:
+
+{list or table including the fields: role, name, affiliation, github username}
+
+|Role |Name |Github Username |Affiliation|
+|:-----|:-----|:-----|:-----|
+| {role} | {names} | {github usernames} | {affiliations}|
+

--- a/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -1,9 +1,18 @@
 # Maintainers
 This is a list of maintainers for this project. See CODEOWNERS for list of reviewers for different parts of the codebase. Team members include:
 
-{list or table including the fields: role, name, affiliation, github username}
+Maintainers:
+- 
 
-|Role |Name |Github Username |Affiliation|
-|:-----|:-----|:-----|:-----|
-| {role} | {names} | {github usernames} | {affiliations}|
+Approvers:
+- 
 
+Reviewers:
+- 
+
+| Roles        | Responsibilities| Requirements  | Defined by|
+| -------------|:---------------|:-------------|:-------------|
+| member       | active contributor in the community | multiple contributions to the project. | PROJECT GitHub org Committer Team|
+| reviewer     | review contributions from other members | history of review and authorship in a subproject | MAINTAINERS file reviewer entry, and GitHub Org Triage Team|
+| approver     | approve accepting contributions | highly experienced and active reviewer + contributor to a subproject  | MAINTAINERS file approver entry and GitHub Triage Team |
+| lead         | set direction and priorities for a subproject | demonstrated responsibility and excellent technical judgement for the subproject |  MAINTAINERS file owner entry and GitHub Org Admin Team|


### PR DESCRIPTION
## Updated MAINTAINERS.md file for Tier 2 and Tier 3

## Problem

Currently, there is no `MAINTAINERS.md` file for Tier 2. The current Tier 3 `MAINTAINERS.md` is actually the Tier 2 version. Additionally, the Tier 3 `MAINTAINERS.md` is missing a table with information on member roles and responsibilities.

## Solution

- Added Tier 2 `MAINTAINERS.md`
- Updated Tier 3 `MAINTAINERS.md`, taken from: https://github.com/DSACMS/dedupliFHIR/blob/main/MAINTAINERS.md?plain=1
- Added member roles and responsibilities table to Tier 3.