### PR TITLE
Add Workflow to Auto-Merge `main` into `dev` 

### DIFF
--- a/.github/workflows/autoMergeMainIntoDev.yml
+++ b/.github/workflows/autoMergeMainIntoDev.yml
@@ -1,0 +1,27 @@
+name: Merge main into dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-dev:
+    permissions: write-all
+    name: update-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: |
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@users.noreply.github.com'
+          git checkout dev
+          git merge main
+          echo "Done with merge"
+      - name: Push to dev
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: dev


### PR DESCRIPTION
## Add Workflow to Auto-Merge `main` into `dev` 

## Problem
Before,  it was possible for `main` to get ahead of the `dev` branch and cause problems for people wanting to contribute to `dev` without first creating a PR. 

## Solution
With this new workflow, `dev` will always be up to date with `main` and the workflow will be available for anyone to use. 
