### PR TITLE
Cookiecutter: Sluggify updated templates with existing variables

### DIFF
--- a/tier0/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier0/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -34,9 +34,9 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 2.  Check out the `main` branch 
 3.  Create a feature branch
 4.  Write code and tests for your change 
-5.  From your branch, make a pull request against `cmsgov/cmsgov-example-repo/main` 
+5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 6.  Work with repo maintainers to get your change reviewed 
-7.  Wait for your change to be pulled into `cmsgov/cmsgov-example-repo/main`
+7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
@@ -87,7 +87,7 @@ TODO: Example Issue Guides
 TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/cmsgov/cmsgov-example-repo/issues).
+docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 <!-- 

--- a/tier0/{{cookiecutter.project_slug}}/README.md
+++ b/tier0/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,4 @@
 # {{ cookiecutter.project_name }}
-
 {{ cookiecutter.project_description }}
 
 ## About the Project
@@ -96,7 +95,7 @@ Pull-requests are merged to `main` and the changes are immediately deployed to t
 
 <!--
 ## Community
-The **{project name}** team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The {{ cookiecutter.project_name }} team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 

--- a/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -36,9 +36,9 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 2.  Check out the `main` branch 
 3.  Create a feature branch
 4.  Write code and tests for your change 
-5.  From your branch, make a pull request against `cmsgov/cmsgov-example-repo/main` 
+5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 6.  Work with repo maintainers to get your change reviewed 
-7.  Wait for your change to be pulled into `cmsgov/cmsgov-example-repo/main`
+7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
@@ -89,7 +89,7 @@ When creating an issue please try to adhere to the following format:
 TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/cmsgov/cmsgov-example-repo/issues).
+docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 ## Policies

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,5 @@
-# **{{ cookiecutter.project_name }}**
-**{{ cookiecutter.project_description }}**
+# {{ cookiecutter.project_name }}
+{{ cookiecutter.project_description }}
 
 ## About the Project
 **{project statement}**
@@ -82,7 +82,7 @@ The contents of this repository are managed by **{responsible organization(s)}**
 
 <!--
 ## Community
-The **{project name}** team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The {{ cookiecutter.project_name }} team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,5 @@
-## **{Project Name}**
-**{project description}**
+# **{{ cookiecutter.project_name }}**
+**{{ cookiecutter.project_description }}**
 
 ## About the Project
 **{project statement}**

--- a/tier2/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier2/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -1,6 +1,6 @@
-# {Project Name} Open Source Community Guidelines
+# {{ cookiecutter.project_name }} Open Source Community Guidelines
 
-This document contains principles and guidelines for participating in the {Project Name} open source community.
+This document contains principles and guidelines for participating in the {{ cookiecutter.project_name }} open source community.
 
 ## Principles
 
@@ -20,13 +20,13 @@ All community members are expected to adhere to our [Code of Conduct](CODE_OF_CO
 
 Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
 
-When participating in {Project Name} open source community conversations and spaces, we ask individuals to follow the following guidelines:
+When participating in {{ cookiecutter.project_name }} open source community conversations and spaces, we ask individuals to follow the following guidelines:
 
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
   - disclosure of any current or potential financial interest in this work
-  - your superpower, and how you hope to use it for {Project Name}
+  - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
 <!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->

--- a/tier2/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier2/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -25,7 +25,6 @@ When participating in {{ cookiecutter.project_name }} open source community conv
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
-  - disclosure of any current or potential financial interest in this work
   - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -41,9 +41,9 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 2.  Check out the `main` branch 
 3.  Create a feature branch
 4.  Write code and tests for your change 
-5.  From your branch, make a pull request against `cmsgov/cmsgov-example-repo/main` 
+5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 6.  Work with repo maintainers to get your change reviewed 
-7.  Wait for your change to be pulled into `cmsgov/cmsgov-example-repo/main`
+7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
@@ -166,7 +166,7 @@ TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, 
 TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/cmsgov/cmsgov-example-repo/issues).
+docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 ## Policies

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -166,7 +166,7 @@ TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, 
 TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue]({{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main).
+docs. Please file an [issue]({{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 ## Policies

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -166,7 +166,7 @@ TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, 
 TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
+docs. Please file an [issue]({{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main).
 -->
 
 ## Policies

--- a/tier2/{{cookiecutter.project_slug}}/README.md
+++ b/tier2/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,5 @@
-## **{Project Name}**
-**{project description}**
+# {{ cookiecutter.project_name }}
+{{ cookiecutter.project_description }}
 
 ## About the Project
 **{project statement}**
@@ -79,7 +79,7 @@ The contents of this repository are managed by **{responsible organization(s)}**
 
 ## Community
 
-The **{project name}** team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The {{ cookiecutter.project_name }} team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -1,6 +1,6 @@
-# {Project Name} Open Source Community Guidelines
+# {{ cookiecutter.project_name }} Open Source Community Guidelines
 
-This document contains principles and guidelines for participating in the {Project Name} open source community.
+This document contains principles and guidelines for participating in the {{ cookiecutter.project_name }} open source community.
 
 ## Principles
 
@@ -20,13 +20,13 @@ All community members are expected to adhere to our [Code of Conduct](CODE_OF_CO
 
 Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
 
-When participating in {Project Name} open source community conversations and spaces, we ask individuals to follow the following guidelines:
+When participating in {{ cookiecutter.project_name }} open source community conversations and spaces, we ask individuals to follow the following guidelines:
 
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
   - disclosure of any current or potential financial interest in this work
-  - your superpower, and how you hope to use it for {Project Name}
+  - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
 <!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -25,7 +25,6 @@ When participating in {{ cookiecutter.project_name }} open source community conv
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
-  - disclosure of any current or potential financial interest in this work
   - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -38,9 +38,9 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 2.  Check out the `main` branch
 3.  Create a feature branch
 4.  Write code and tests for your change
-5.  From your branch, make a pull request against `cmsgov/cmsgov-example-repo/main`
+5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 6.  Work with repo maintainers to get your change reviewed
-7.  Wait for your change to be pulled into `cmsgov/cmsgov-example-repo/main`
+7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
@@ -161,7 +161,7 @@ authorship metadata will be preserved.
 <!-- TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/cmsgov/cmsgov-example-repo/issues).
+docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 ## Policies

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,5 @@
-## **{Project Name}**
-**{project description}**
+# {{ cookiecutter.project_name }}
+{{ cookiecutter.project_description }}
 
 ## About the Project
 **{project statement}**
@@ -77,7 +77,7 @@ The contents of this repository are managed by **{responsible organization(s)}**
 
 ## Community
 
-The **{project name}** team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The {{ cookiecutter.project_name }} team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 
@@ -89,7 +89,7 @@ Principles and guidelines for participating in our open source community are can
 
 <!--
 ## Governance
-Information about how the **{project_name}** community is governed may be found in [GOVERNANCE.md](GOVERNANCE.md).
+Information about how the {{ cookiecutter.project_name }} community is governed may be found in [GOVERNANCE.md](GOVERNANCE.md).
 -->
 
 ## Feedback

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -1,6 +1,6 @@
-# {Project Name} Open Source Community Guidelines
+# {{ cookiecutter.project_name }} Open Source Community Guidelines
 
-This document contains principles and guidelines for participating in the {Project Name} open source community.
+This document contains principles and guidelines for participating in the {{ cookiecutter.project_name }} open source community.
 
 ## Principles
 
@@ -20,13 +20,13 @@ All community members are expected to adhere to our [Code of Conduct](CODE_OF_CO
 
 Information on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).
 
-When participating in {Project Name} open source community conversations and spaces, we ask individuals to follow the following guidelines:
+When participating in {{ cookiecutter.project_name }} open source community conversations and spaces, we ask individuals to follow the following guidelines:
 
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
   - disclosure of any current or potential financial interest in this work
-  - your superpower, and how you hope to use it for {Project Name}
+  - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.
 <!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to _be here_? -->

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY_GUIDELINES.md
@@ -25,7 +25,6 @@ When participating in {{ cookiecutter.project_name }} open source community conv
 - When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:
   - your related organization (if applicable)
   - your pronouns
-  - disclosure of any current or potential financial interest in this work
   - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}
 - Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.
 - Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -38,9 +38,9 @@ We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow
 2.  Check out the `main` branch
 3.  Create a feature branch
 4.  Write code and tests for your change
-5.  From your branch, make a pull request against `cmsgov/cmsgov-example-repo/main`
+5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 6.  Work with repo maintainers to get your change reviewed
-7.  Wait for your change to be pulled into `cmsgov/cmsgov-example-repo/main`
+7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
@@ -161,7 +161,7 @@ authorship metadata will be preserved.
 <!-- TODO: Documentation Example
 
 We also welcome improvements to the project documentation or to the existing
-docs. Please file an [issue](https://github.com/cmsgov/cmsgov-example-repo/issues).
+docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
 ## Policies

--- a/tier4/{{cookiecutter.project_slug}}/README.md
+++ b/tier4/{{cookiecutter.project_slug}}/README.md
@@ -1,5 +1,5 @@
-## **{project_name}**
-**{project_description}**
+# {{ cookiecutter.project_name }}
+{{ cookiecutter.project_description }}
 
 ## About the Project
 **{project_statement}**
@@ -67,7 +67,7 @@ The contents of this repository are managed by **{responsible organization(s)}**
 
 ## Community
 
-The **{project_name}** team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The {{ cookiecutter.project_name }} team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 
@@ -78,8 +78,9 @@ We also recognize capacity building as a key part of involving a diverse open so
 Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. 
 
 ## Governance
-
 <!-- TODO: Make a short statement about how the project is governed (formally, or informally) and link to the GOVERNANCE.md file.-->
+
+Information about how the {{ cookiecutter.project_name }} community is governed may be found in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Feedback
 


### PR DESCRIPTION
## Cookiecutter: Sluggify updated templates with existing variables

## Problem

Throughout the past couple of weeks, we have been making extensive updates to markdown templates in all tiers. We would like to sluggify the updated templates with existing variables from cookiecutter.json.

## Solution

README.md
- Added `project_name` and `project_description` variables at top

CONTRIBUTING.md
- Updated branches with `project_org` and `project_repo_name` variables in Workflow and Branching section
- Updated links with `project_org` and `project_repo_name` variables in Documentation section
- Added `project_name` variable

COMMUNITY_GUIDELINES
- Added `project_name` variable