### PR TITLE
Templates: Minor Fixes

### DIFF
--- a/maturity-model-tiers.md
+++ b/maturity-model-tiers.md
@@ -21,7 +21,7 @@ This document outlines the maturity model tiers.
       <td>Working projects, Example Code, Early Prototypes</td>
     </tr>
     <tr>
-      <td>Tier   1</td>
+      <td>Tier 1</td>
       <td>One-Time Release</td>
       <td>Informational/Historical</td>
       <td>Paper publishing, Historical Archival</td>

--- a/maturity-model-tiers.md
+++ b/maturity-model-tiers.md
@@ -21,7 +21,7 @@ This document outlines the maturity model tiers.
       <td>Working projects, Example Code, Early Prototypes</td>
     </tr>
     <tr>
-      <td>Tier 1  </td> Fix spacing problem
+      <td>Tier   1</td>
       <td>One-Time Release</td>
       <td>Informational/Historical</td>
       <td>Paper publishing, Historical Archival</td>

--- a/tier1/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repolinter.json
@@ -734,7 +734,7 @@
         }
       },
       "code-owners-contains-repo-domains": {
-        "level": "warning",
+        "level": "off",
         "rule": {
           "type": "file-contents",
           "options": {

--- a/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -2,6 +2,7 @@
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.-->
 This is a list of maintainers for this project. See [CODEOWNERS.md](./CODEOWNERS.md) for list of reviewers for different parts of the codebase. Team members include:
 
+## Maintainers:
 {list or table including the fields: role, name, affiliation, github username}
 
 |Role |Name |Github Username |Affiliation|

--- a/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -2,14 +2,14 @@
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.-->
 This is a list of maintainers for this project. See [CODEOWNERS.md](./CODEOWNERS.md) for list of reviewers for different parts of the codebase. Team members include:
 
-Maintainers:
+## Maintainers:
 <!-- TODO: What groups/domains are maintainers a part of? Does your project have domains/areas that are maintained by specific people? List @USERNAMES directly, or any @ALIASES for groups/teams.-->
 - 
 
-Approvers:
+## Approvers:
 - 
 
-Reviewers:
+## Reviewers:
 - 
 
 | Roles        | Responsibilities| Requirements  | Defined by|


### PR DESCRIPTION
## Templates: Minor Fixes

## Problem

Identified minor fixes to templates now that repolinter.json files are merged

## Solution

Fixes include:
- `code-owners-contains-repo-domains` level changed to off in tier 1 since `CODEOWNERS.md` is not recommended for Tier 1
- Added missing "Headers:" to Tier 2 `MAINTAINERS.md` fulfill repolinter check
- Reformatted headers in `MAINTAINERS.md`
- Fixed spacing