### PR TITLE
fix post gen project hook bug in tiers 0-2

### DIFF
--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -30,8 +30,8 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
-if CREATE_REPO:
+if CREATE_REPO == "True":
     createGithubRepo()
 
-if RECEIVE_UPDATES:
+if RECEIVE_UPDATES == "True":
     addTopic()

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -30,8 +30,8 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
-if CREATE_REPO:
+if CREATE_REPO == "True":
     createGithubRepo()
 
-if RECEIVE_UPDATES:
+if RECEIVE_UPDATES == "True":
     addTopic()

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -30,8 +30,8 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
-if CREATE_REPO:
+if CREATE_REPO == "True":
     createGithubRepo()
 
-if RECEIVE_UPDATES:
+if RECEIVE_UPDATES == "True":
     addTopic()


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Fix boolean type bug in cookiecutter Tier 0-2 hook

## Problem

In tiers 0, 1, and 2, when being asked the following:

```
 [7/8] Would you like to create a repo on github.com?
    1 - True
    2 - False
    Choose from [1/2] (1): 2
  [8/8] Would you like to receive updates from ...
    1 - True
    2 - False
    Choose from [1/2] (1): 2
```

Selecting false proceeds to be true anyway, because in the
hook, the Python variable is actually a string and so the truthy value
of "False" is True.

## Solution

I changed `if CREATE_REPO:` to `if CREATE_REPO == "True":`.

## Result

Now, selecting False for those two prompts will not proceed to
run the hook functions as unintended.
