### PR TITLE
fix Jinja template conflict with Github Action

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -15,7 +15,9 @@ jobs:
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
     env:
-      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json}}
+      {% raw %}
+      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
+      {% endraw %}
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -15,7 +15,9 @@ jobs:
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
     env:
-      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json}}
+      {% raw %}
+      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
+      {% endraw %}
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -15,7 +15,9 @@ jobs:
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
     env:
-      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json}}
+      {% raw %}
+      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
+      {% endraw %}
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Fix Jinja template conflict with Github Action

## Problem

When using cookiecutter on Tiers 2, 3, or 4, cookiecutter tries to replace the `needs` variable within the scope `${{ }}` in the Github Action script, but the `${{ }}` will actually be interpolated at the Github Action level, not the Jinja level, so that scope needs to be escaped by adding `{% raw %}`.

## Solution

I added `{% raw %}` to the three Github Action scripts to escape the `${{ }}`.

## Result

Running cookie cutter on tiers 2-4 now exit cleanly without an error.
