### PR TITLE
MAINTAINERS.md needs to be properly slugified at all tiers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,13 @@
     "MAINTAIN": "Do you plan on having other individuals/teams outside the agency maintain the project with you?",
     "ROADMAP": "Do you plan on having other individuals/teams outside the agency plan the development roadmap with you?",
     "template": "We suggest using this template:"
-  }
+  },
+  "maintainers": [
+    {
+      "name": "Name",
+      "github_username": "GitHub username",
+      "role": "Choose One: reviewer, approver, maintainer"
+      "affiliation": "Affiliation"
+    }
+  ]
 }

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -15,8 +15,8 @@
         {
             "name": "Name",
             "github_username": "GitHub username",
-            "role": "Choose One: reviewer, approver, maintainer"
-            "affiliation": "Affiliation"
+            "role": "Choose One: reviewer, approver, maintainer",
+            "affiliation": "DSAC, CCSQ, CMMI, etc..."
         }
     ]
 }

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -10,5 +10,13 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
-    }
+    },
+    "maintainers": [
+        {
+            "name": "Name",
+            "github_username": "GitHub username",
+            "role": "Choose One: reviewer, approver, maintainer"
+            "affiliation": "Affiliation"
+        }
+    ]
 }

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -15,8 +15,8 @@
         {
             "name": "Name",
             "github_username": "GitHub username",
-            "role": "Choose One: reviewer, approver, maintainer"
-            "affiliation": "Affiliation"
+            "role": "Choose One: reviewer, approver, maintainer",
+            "affiliation": "DSAC, CCSQ, CMMI, etc..."
         }
     ]
 }

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -10,5 +10,13 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
-    }
+    },
+    "maintainers": [
+        {
+            "name": "Name",
+            "github_username": "GitHub username",
+            "role": "Choose One: reviewer, approver, maintainer"
+            "affiliation": "Affiliation"
+        }
+    ]
 }

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -10,5 +10,13 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
-    }
+    },
+    "maintainers": [
+      {
+          "name": "Name",
+          "github_username": "GitHub username",
+          "role": "Choose One: reviewer, approver, maintainer",
+          "affiliation": "DSAC, CCSQ, CMMI, etc..."
+      }
+  ]
 }


### PR DESCRIPTION
## MAINTAINERS.md needs to be properly slugified at all tiers

## Problem

The `cookiecutter.json` files in tiers 2-4 need to be updated to account for `MAINTAINERS.md`.

## Solution

Update each `cookiecutter.json` file for each respective tier to account for the new variables in `MAINTAINERS.md`.

## Result

`cookiecutter.json` files are updated with the new variables (name, github username, role, and affiliation) that are found in `MAINTAINERS.md`. May need to edit some YAML files or other automated tasks to make it more streamlined.