### PR TITLE
Fix Jinja template problem with secrets in Github actions

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -16,7 +16,9 @@ jobs:
             - name: Contribute List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
               env:
+                  {% raw %}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  {% endraw %}
               with:
                   # https://github.com/marketplace/actions/contribute-list#optional-parameters
                   readme_path: MAINTAINERS.md
@@ -38,18 +40,22 @@ jobs:
               # https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#communicating-with-graphql
               # CANNOT have newlines!
               run: |
+                  {% raw %}
                   OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
                   REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
                   QUERY='query { repository(owner: \"'"$OWNER"'\", name: \"'"$REPO"'\") { collaborators { totalCount } } }'
                   CONTRIBUTORS=$(curl -s -X POST -H "Authorization: bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"query\": \"$QUERY\"}" https://api.github.com/graphql | jq -r '.data.repository.collaborators.totalCount')
                   echo "Total contributors: $CONTRIBUTORS"
                   echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+                  {% endraw %}
 
             - name: Replace slug in MAINTAINERS.md with number of contributors
               # https://stackoverflow.com/questions/10613643/replace-a-unknown-string-between-two-known-strings-with-sed
               run: |
+                  {% raw %}
                   CONTRIBUTORS=${{ steps.get_contributors.outputs.contributors }}
                   sed -i 's/<!--CONTRIBUTOR COUNT START-->.*<!--CONTRIBUTOR COUNT END-->/<!--CONTRIBUTOR COUNT START--> '"$CONTRIBUTORS"' <!--CONTRIBUTOR COUNT END-->/g' MAINTAINERS.md
+                  {% endraw %}
 
             - name: Commit and push changes
               # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -16,7 +16,9 @@ jobs:
             - name: Contribute List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
               env:
+                  {% raw %}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  {% endraw %}
               with:
                   # https://github.com/marketplace/actions/contribute-list#optional-parameters
                   readme_path: MAINTAINERS.md
@@ -38,18 +40,22 @@ jobs:
               # https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#communicating-with-graphql
               # CANNOT have newlines!
               run: |
+                  {% raw %}
                   OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
                   REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
                   QUERY='query { repository(owner: \"'"$OWNER"'\", name: \"'"$REPO"'\") { collaborators { totalCount } } }'
                   CONTRIBUTORS=$(curl -s -X POST -H "Authorization: bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"query\": \"$QUERY\"}" https://api.github.com/graphql | jq -r '.data.repository.collaborators.totalCount')
                   echo "Total contributors: $CONTRIBUTORS"
                   echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+                  {% endraw %}
 
             - name: Replace slug in MAINTAINERS.md with number of contributors
               # https://stackoverflow.com/questions/10613643/replace-a-unknown-string-between-two-known-strings-with-sed
               run: |
+                  {% raw %}
                   CONTRIBUTORS=${{ steps.get_contributors.outputs.contributors }}
                   sed -i 's/<!--CONTRIBUTOR COUNT START-->.*<!--CONTRIBUTOR COUNT END-->/<!--CONTRIBUTOR COUNT START--> '"$CONTRIBUTORS"' <!--CONTRIBUTOR COUNT END-->/g' MAINTAINERS.md
+                  {% endraw %}
 
             - name: Commit and push changes
               # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -16,7 +16,9 @@ jobs:
             - name: Contribute List
               uses: akhilmhdh/contributors-readme-action@v2.3.10
               env:
+                  {% raw %}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  {% endraw %}
               with:
                   # https://github.com/marketplace/actions/contribute-list#optional-parameters
                   readme_path: MAINTAINERS.md
@@ -38,18 +40,22 @@ jobs:
               # https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#communicating-with-graphql
               # CANNOT have newlines!
               run: |
+                  {% raw %}
                   OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
                   REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
                   QUERY='query { repository(owner: \"'"$OWNER"'\", name: \"'"$REPO"'\") { collaborators { totalCount } } }'
                   CONTRIBUTORS=$(curl -s -X POST -H "Authorization: bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"query\": \"$QUERY\"}" https://api.github.com/graphql | jq -r '.data.repository.collaborators.totalCount')
                   echo "Total contributors: $CONTRIBUTORS"
                   echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
+                  {% endraw %}
 
             - name: Replace slug in MAINTAINERS.md with number of contributors
               # https://stackoverflow.com/questions/10613643/replace-a-unknown-string-between-two-known-strings-with-sed
               run: |
+                  {% raw %}
                   CONTRIBUTORS=${{ steps.get_contributors.outputs.contributors }}
                   sed -i 's/<!--CONTRIBUTOR COUNT START-->.*<!--CONTRIBUTOR COUNT END-->/<!--CONTRIBUTOR COUNT START--> '"$CONTRIBUTORS"' <!--CONTRIBUTOR COUNT END-->/g' MAINTAINERS.md
+                  {% endraw %}
 
             - name: Commit and push changes
               # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Fix Jinja template problem with secrets in Github actions

## Problem

When running cookiecutter for this repo the following error is produced:
`Unable to create file '.github/workflows/contributors.yml'
Error message: 'secrets' is undefined`

## Solution

Similar to #99. 

## Result

When this patch was applied I was successfully able to use cookiecutter.

## Test Plan

Tested on a repo I was creating.