### PR TITLE
Add Repometrics to Tier 1

### DIFF
--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -10,5 +10,6 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
-    }
+    },
+    "_copy_without_render": ["repometrics"]
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,0 +1,18 @@
+{
+    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
+    "user_input": ["Yes", "No"],
+    "project_fisma_level": ["Low", "Moderate", "High"],
+    "group": "CMS/OA/DSAC",
+    "subset_in_healthcare": "Policy, Operational",
+    "user_type": "Providers, Patients, Government",
+    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "maturity_model_tier": ["1", "2", "3", "4"],
+    "__prompts__": {
+        "group": "Which group is the project part of?",
+        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
+        "user_type": "Who are the intended users?",
+        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
+        "repository_host": "Where is the repository hosted?",
+        "maturity_model_tier": "What maturity model tier is your project classified as?"
+    }
+}

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/hooks/post_gen_project.sh
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/hooks/post_gen_project.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Change to the parent directory
+cd ..
+
+# Define the repometrics directory to remove
+dir_name="repometrics"
+
+# Check if repometrics directory exists and remove it
+if [ -d "$dir_name" ]; then
+  rm -rf "$dir_name"
+fi
+
+project_type="{{cookiecutter.project_type}}"
+sub_project_dir="${project_type}"
+repometrics_file="code.json"
+parent_dir="./"
+
+if [ -f "${sub_project_dir}/${repometrics_file}" ]; then  
+  # Move code.json file to parent directory
+  mv "${sub_project_dir}/${repometrics_file}" "${parent_dir}"
+  
+  # Check if the move was successful
+  if [ $? -eq 0 ]; then    
+    # Remove the source directory
+    rm -rf "${sub_project_dir}"
+    
+    # Check if the deletion was successful
+    if [ $? -eq 0 ]; then
+      echo "Successfully generated code.json file."
+    fi
+  fi
+fi

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,0 +1,10 @@
+{
+    "project_type": "{{ cookiecutter.project_type }}",
+    "user_input": "{{ cookiecutter.user_input }}",
+    "project_fisma_level": "{{ cookiecutter.project_fisma_level }}",
+    "group": "{{ cookiecutter.group }}",
+    "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
+    "user_type": "{{ cookiecutter.user_type }}",
+    "repository_host": "{{ cookiecutter.repository_host }}",
+    "maturity_model_tier": "{{ cookiecutter.maturity_model_tier }}"
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Add Repometrics to Tier 1

## Problem

Currently, we want to add metrics to the repo reports that include where it is hosted, project fisma level, project type, etc. We will be using this to create tags in the reports and help create visualizations.

## Solution

Created a cookiecutter template that asks multiple choice and free response questions, the code.json will be generated inside the project that is created by cookiecutter and moved to parent directory.