### PR TITLE
Add workflow_call trigger to workflow

### DIFF
--- a/.github/workflows/extendJSONFile.yml
+++ b/.github/workflows/extendJSONFile.yml
@@ -8,6 +8,13 @@ on:
         default: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      url_to_json:
+        description: 'URL to JSON file'
+        default: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
+        required: true
+        type: string
 
 jobs:
   extend-json:


### PR DESCRIPTION
## module-name: Add `workflow_call` trigger

## Problem

When using the `repo-scaffolder` I was receiving the following error message in the `checks.yml`:

``` Invalid workflow file

error parsing called workflow
".github/workflows/checks.yml"
-> "DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows" (source branch with sha:f06340f5e852f5ac242bf492d7930e7a3d376481)
: workflow is not reusable as it is missing a `on.workflow_call` trigger

```

## Solution

Add the `workflow_call` trigger to the yml file.

## Result

Should be able to use the workflow now.

## Test Plan

