### PR TITLE
Add tree repo structure GH Action

### DIFF
--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/repoStructure.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/repoStructure.yml
@@ -1,0 +1,37 @@
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    populate-repo-structure:
+        runs-on: ubuntu-latest
+        name: Update repo structure in README.md
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Populate repository structure with tree command
+              # https://stackoverflow.com/questions/29613304/is-it-possible-to-escape-regex-metacharacters-reliably-with-sed
+              # https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern
+              run: |
+                  quoteSubst() {
+                    IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's/[&/\]/\\&/g; s/\n/\\&/g' <<<"$1")
+                    printf %s "${REPLY%$'\n'}"
+                  }
+                  TREE_OUTPUT=$(tree -d)
+                  sed -i 's/<!--TREE START--><!--TREE END-->/\n```plaintext\n'"$(quoteSubst $TREE_OUTPUT)"'\n```\n/g' README.md
+
+            - name: Commit and push changes
+              # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+              # commit changes, but if no changes exist, then exit cleanly
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add README.md
+                  git commit -m "BOT: Update repo structure in README.md" || exit 0
+                  git push

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -33,6 +33,7 @@ An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAI
 ## Repository Structure
 
 <!-- TODO: Using the "tree -d" command can be a helpful way to generate this information, but, be sure to update it as the project evolves and changes over time.-->
+<!--TREE START--><!--TREE END-->
 
 **{list directories and descriptions}**
 

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/repoStructure.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/repoStructure.yml
@@ -1,0 +1,37 @@
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+jobs:
+    populate-repo-structure:
+        runs-on: ubuntu-latest
+        name: Update repo structure in README.md
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Populate repository structure with tree command
+              # https://stackoverflow.com/questions/29613304/is-it-possible-to-escape-regex-metacharacters-reliably-with-sed
+              # https://stackoverflow.com/questions/407523/escape-a-string-for-a-sed-replace-pattern
+              run: |
+                  quoteSubst() {
+                    IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's/[&/\]/\\&/g; s/\n/\\&/g' <<<"$1")
+                    printf %s "${REPLY%$'\n'}"
+                  }
+                  TREE_OUTPUT=$(tree -d)
+                  sed -i 's/<!--TREE START--><!--TREE END-->/\n```plaintext\n'"$(quoteSubst $TREE_OUTPUT)"'\n```\n/g' README.md
+
+            - name: Commit and push changes
+              # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+              # commit changes, but if no changes exist, then exit cleanly
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add README.md
+                  git commit -m "BOT: Update repo structure in README.md" || exit 0
+                  git push

--- a/tier4/{{cookiecutter.project_slug}}/README.md
+++ b/tier4/{{cookiecutter.project_slug}}/README.md
@@ -25,6 +25,7 @@ An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAI
 ## Repository Structure
 
 <!-- TODO: Using the "tree -d" command can be a helpful way to generate this information, but, be sure to update it as the project evolves and changes over time. -->
+<!--TREE START--><!--TREE END-->
 
 **{list directories and descriptions}**
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## Add tree repo structure GH Action

## Problem

Currently, developers have to manually input their project's repository
structure in the README.

## Solution

This Github Action automatically generates the directory structure in the
relevant part of the README by using the `tree` Bash command.
