### PR TITLE
Remove Maturity Model Cookiecutter Prompt

### DIFF
--- a/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -6,13 +6,11 @@
     "subset_in_healthcare": "Policy, Operational",
     "user_type": "Providers, Patients, Government",
     "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
-    "maturity_model_tier": ["1", "2", "3", "4"],
     "__prompts__": {
         "group": "Which group is the project part of?",
         "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
         "user_type": "Who are the intended users?",
         "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?",
-        "maturity_model_tier": "What maturity model tier is your project classified as?"
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -6,5 +6,5 @@
     "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
     "user_type": "{{ cookiecutter.user_type }}",
     "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "{{ cookiecutter.maturity_model_tier }}"
+    "maturity_model_tier": "1"
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -6,13 +6,11 @@
     "subset_in_healthcare": "Policy, Operational",
     "user_type": "Providers, Patients, Government",
     "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
-    "maturity_model_tier": ["1", "2", "3", "4"],
     "__prompts__": {
         "group": "Which group is the project part of?",
         "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
         "user_type": "Who are the intended users?",
         "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?",
-        "maturity_model_tier": "What maturity model tier is your project classified as?"
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -6,5 +6,5 @@
     "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
     "user_type": "{{ cookiecutter.user_type }}",
     "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "{{ cookiecutter.maturity_model_tier }}"
+    "maturity_model_tier": "2"
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -6,13 +6,11 @@
     "subset_in_healthcare": "Policy, Operational",
     "user_type": "Providers, Patients, Government",
     "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
-    "maturity_model_tier": ["1", "2", "3", "4"],
     "__prompts__": {
         "group": "Which group is the project part of?",
         "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
         "user_type": "Who are the intended users?",
         "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?",
-        "maturity_model_tier": "What maturity model tier is your project classified as?"
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -6,5 +6,5 @@
     "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
     "user_type": "{{ cookiecutter.user_type }}",
     "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "{{ cookiecutter.maturity_model_tier }}"
+    "maturity_model_tier": "3"
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -6,13 +6,11 @@
     "subset_in_healthcare": "Policy, Operational",
     "user_type": "Providers, Patients, Government",
     "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
-    "maturity_model_tier": ["1", "2", "3", "4"],
     "__prompts__": {
         "group": "Which group is the project part of?",
         "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
         "user_type": "Who are the intended users?",
         "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?",
-        "maturity_model_tier": "What maturity model tier is your project classified as?"
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -6,5 +6,5 @@
     "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
     "user_type": "{{ cookiecutter.user_type }}",
     "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "{{ cookiecutter.maturity_model_tier }}"
+    "maturity_model_tier": "4"
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## module-name: Remove Maturity Model Cookiecutter Prompt

## Problem

Currently in cookiecutter, we ask the user to select maturity model. There is a chance users can pick the wrong maturity model. Based on number selected, it is stored in the maturity_model_tier variable in code.json. 

## Solution

Remove maturity_model_tier question in cookiecutter.json, and add tier directly based on directory/tier.

## Result

Reducing chances of incorrect/misleading metadata.