### PR TITLE
Tier 1: Fix for project generation due to error in checks.yml

### DIFF
--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -15,7 +15,9 @@ jobs:
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
     env:
+      {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json}}
+      {% endraw %}
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json


### PR DESCRIPTION
## Tier 1: Fix for project generation due to error in checks.yml

## Problem

When using repo-scaffolder to create a new Tier 1 project, an error occurred due to the checks.yml file failing to create. `needs:` is undefined.

## Solution

Added raw json tag to `needs.resolve-repolinter-json.outputs.raw-json`. Fix is similar to https://github.com/DSACMS/repo-scaffolder/pull/99

## Result

Project generation for Tier 1 are successfully created now