### PR TITLE
Fix Issues With Checks.yml workflow 

### DIFF
--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -1,12 +1,12 @@
 name: "run-linting-checks"
 on:
-  pull_request:
-    branches: [main, dev]
-
+  push:
+    branches:
+      - 'main'
 
 jobs:
   resolve-repolinter-json:
-    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows
+    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
   
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       {% raw %}
-      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json}}
+      RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
       {% endraw %}
     steps:
       - uses: actions/checkout@v4
@@ -52,20 +52,6 @@ jobs:
           # Default: "[Repolinter] Open Source Policy Issues"
           output_name: '[Repolinter] Tier 1 Repository Hygiene Issue'
 
-          # The name to use for the issue label created by repolinter-action. This name
-          # should be unique to repolinter-action (i.e. not used by any other issue) to
-          # prevent repolinter-action from getting confused.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "repolinter"
-          label_name: 'cms-oss-tier1'
-
-          # The color to use for the issue label created by repolinter-action. The value
-          # for this option should be an unprefixed RRGGBB hex string (ex. ff568a).
-          # The default value is a shade of yellow.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "fbca04"
-          label_color: 'ff69b4'
+          # The default token is the repolinter token for the DSACMS org
+          # You can change it if needed.
+          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -1,12 +1,12 @@
 name: "run-linting-checks"
 on:
-  pull_request:
-    branches: [main, dev]
-
+  push:
+    branches:
+      - 'main'
 
 jobs:
   resolve-repolinter-json:
-    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows
+    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier2/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
   
@@ -52,20 +52,6 @@ jobs:
           # Default: "[Repolinter] Open Source Policy Issues"
           output_name: '[Repolinter] Tier 2 Repository Hygiene Issue'
 
-          # The name to use for the issue label created by repolinter-action. This name
-          # should be unique to repolinter-action (i.e. not used by any other issue) to
-          # prevent repolinter-action from getting confused.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "repolinter"
-          label_name: 'cms-oss-tier2'
-
-          # The color to use for the issue label created by repolinter-action. The value
-          # for this option should be an unprefixed RRGGBB hex string (ex. ff568a).
-          # The default value is a shade of yellow.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "fbca04"
-          label_color: 'ff69b4'
+          # The default token is the repolinter token for the DSACMS org
+          # You can change it if needed.
+          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -1,12 +1,12 @@
 name: "run-linting-checks"
 on:
-  pull_request:
-    branches: [main, dev]
-
+  push:
+    branches:
+      - 'main'
 
 jobs:
   resolve-repolinter-json:
-    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows
+    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
   
@@ -52,20 +52,6 @@ jobs:
           # Default: "[Repolinter] Open Source Policy Issues"
           output_name: '[Repolinter] Tier 3 Repository Hygiene Issue'
 
-          # The name to use for the issue label created by repolinter-action. This name
-          # should be unique to repolinter-action (i.e. not used by any other issue) to
-          # prevent repolinter-action from getting confused.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "repolinter"
-          label_name: 'cms-oss-tier3'
-
-          # The color to use for the issue label created by repolinter-action. The value
-          # for this option should be an unprefixed RRGGBB hex string (ex. ff568a).
-          # The default value is a shade of yellow.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "fbca04"
-          label_color: 'ff69b4'
+          # The default token is the repolinter token for the DSACMS org
+          # You can change it if needed.
+          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -1,12 +1,12 @@
 name: "run-linting-checks"
 on:
-  pull_request:
-    branches: [main, dev]
-
+  push:
+    branches:
+      - 'main'
 
 jobs:
   resolve-repolinter-json:
-    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@add-repolinter-workflows
+    uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier4/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
   
@@ -52,20 +52,6 @@ jobs:
           # Default: "[Repolinter] Open Source Policy Issues"
           output_name: '[Repolinter] Tier 4 Repository Hygiene Issue'
 
-          # The name to use for the issue label created by repolinter-action. This name
-          # should be unique to repolinter-action (i.e. not used by any other issue) to
-          # prevent repolinter-action from getting confused.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "repolinter"
-          label_name: 'cms-oss-tier4'
-
-          # The color to use for the issue label created by repolinter-action. The value
-          # for this option should be an unprefixed RRGGBB hex string (ex. ff568a).
-          # The default value is a shade of yellow.
-          #
-          # This option will be ignored if output_type != "issue".
-          #
-          # Default: "fbca04"
-          label_color: 'ff69b4'
+          # The default token is the repolinter token for the DSACMS org
+          # You can change it if needed.
+          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}


### PR DESCRIPTION
## Fix Issues With Checks.yml workflow 

## Problem

The checks.yml file was not working when I was trying to use it on my recently generated [repodive-tools repository 
](https://github.com/DSACMS/repodive-tools). It was failing to create the label for the desired issue properly.

Also, it doesn't make sense to run the checks.yml on pull requests because it is an action that is supposed to update an issue and issues are supposed to releflect the canon state of the project. If we run it on pending changes then the issue won't make sense. 

## Solution

Make the workflow run on push to main. Also use the main version of the `extendJSONFile` workflow instead of the dev version that didn't work. Also, add a standard api key to use for this action as a secret in the DSACMS org. I also removed the label logic from the checks.yml file because it wasn't working. 
