### PR TITLE
Fix contributors automation

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -1,8 +1,8 @@
 on:
-    push:
-        branches:
-            - main
-    workflow_dispatch:
+    workflow_dispatch: {}
+    schedule:
+        # Weekly on Saturdays.
+        - cron: "30 1 * * 6"
 
 jobs:
     update-contributors:

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -1,8 +1,8 @@
 on:
-    push:
-        branches:
-            - main
-    workflow_dispatch:
+    workflow_dispatch: {}
+    schedule:
+        # Weekly on Saturdays.
+        - cron: "30 1 * * 6"
 
 jobs:
     update-contributors:

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -1,8 +1,8 @@
 on:
-    push:
-        branches:
-            - main
-    workflow_dispatch:
+    workflow_dispatch: {}
+    schedule:
+        # Weekly on Saturdays.
+        - cron: "30 1 * * 6"
 
 jobs:
     update-contributors:


### PR DESCRIPTION
## Fix contributors automation

## Problem

The current Github Action causes an infinite loop.

## Solution

This updated workflow uses a cron job to prevent an infinite loop. It also overrides pushes to protected branches.
