### PR TITLE
Camel Case code.json Fields

### DIFF
--- a/code.json
+++ b/code.json
@@ -1,10 +1,10 @@
 {
-    "project_type": "Tools",
-    "user_input": "No",
-    "project_fisma_level": "Low",
+    "projectType": "Tools",
+    "userInput": "No",
+    "projectFismaLevel": "Low",
     "group": "CMS/OA/DSAC",
-    "subset_in_healthcare": "Operational",
-    "user_type": "Government",
-    "repository_host": "Github.com",
-    "maturity_model_tier": "3"
+    "subsetInHealthcare": "Operational",
+    "userType": "Government",
+    "repositoryHost": "Github.com",
+    "maturityModelTier": "3"
 }

--- a/code.json
+++ b/code.json
@@ -1,7 +1,7 @@
 {
     "projectType": "Tools",
     "userInput": "No",
-    "projectFismaLevel": "Low",
+    "fismaLevel": "Low",
     "group": "CMS/OA/DSAC",
     "subsetInHealthcare": "Operational",
     "userType": "Government",

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
-    "user_input": ["Yes", "No"],
-    "project_fisma_level": ["Low", "Moderate", "High"],
+    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "userInput": ["Yes", "No"],
+    "projectFismaLevel": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subset_in_healthcare": "Policy, Operational",
-    "user_type": "Providers, Patients, Government",
-    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subsetInHealthcare": "Policy, Operational",
+    "userType": "Providers, Patients, Government",
+    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
-        "user_type": "Who are the intended users?",
-        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?"
+        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
+        "userType": "Who are the intended users?",
+        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repositoryHost": "Where is the repository hosted?"
     }
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
-    "userInput": ["Yes", "No"],
-    "projectFismaLevel": ["Low", "Moderate", "High"],
+    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "user_input": ["Yes", "No"],
+    "fisma_level": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subsetInHealthcare": "Policy, Operational",
-    "userType": "Providers, Patients, Government",
-    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subset_in_healthcare": "Policy, Operational",
+    "user_type": "Providers, Patients, Government",
+    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
-        "userType": "Who are the intended users?",
-        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
-        "repositoryHost": "Where is the repository hosted?"
+        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
+        "user_type": "Who are the intended users?",
+        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "projectType": "{{ cookiecutter.projectType }}",
-    "userInput": "{{ cookiecutter.userInput }}",
-    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
+    "projectType": "{{ cookiecutter.project_type }}",
+    "userInput": "{{ cookiecutter.user_nput }}",
+    "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
-    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
-    "userType": "{{ cookiecutter.userType }}",
-    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
-    "maturity_model_tier": "1"
+    "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
+    "userType": "{{ cookiecutter.user_ype }}",
+    "repositoryHost": "{{ cookiecutter.repository_host }}",
+    "maturityModelTier": "1"
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
     "projectType": "{{ cookiecutter.project_type }}",
-    "userInput": "{{ cookiecutter.user_nput }}",
+    "userInput": "{{ cookiecutter.user_input }}",
     "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
     "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "userType": "{{ cookiecutter.user_ype }}",
+    "userType": "{{ cookiecutter.user_type }}",
     "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "1"
 }

--- a/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier1/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "project_type": "{{ cookiecutter.project_type }}",
-    "user_input": "{{ cookiecutter.user_input }}",
-    "project_fisma_level": "{{ cookiecutter.project_fisma_level }}",
+    "projectType": "{{ cookiecutter.projectType }}",
+    "userInput": "{{ cookiecutter.userInput }}",
+    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
     "group": "{{ cookiecutter.group }}",
-    "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "user_type": "{{ cookiecutter.user_type }}",
-    "repository_host": "{{ cookiecutter.repository_host }}",
+    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
+    "userType": "{{ cookiecutter.userType }}",
+    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
     "maturity_model_tier": "1"
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
-    "user_input": ["Yes", "No"],
-    "project_fisma_level": ["Low", "Moderate", "High"],
+    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "userInput": ["Yes", "No"],
+    "projectFismaLevel": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subset_in_healthcare": "Policy, Operational",
-    "user_type": "Providers, Patients, Government",
-    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subsetInHealthcare": "Policy, Operational",
+    "userType": "Providers, Patients, Government",
+    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
-        "user_type": "Who are the intended users?",
-        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?"
+        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
+        "userType": "Who are the intended users?",
+        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repositoryHost": "Where is the repository hosted?"
     }
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
-    "userInput": ["Yes", "No"],
-    "projectFismaLevel": ["Low", "Moderate", "High"],
+    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "user_input": ["Yes", "No"],
+    "fisma_level": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subsetInHealthcare": "Policy, Operational",
-    "userType": "Providers, Patients, Government",
-    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subset_in_healthcare": "Policy, Operational",
+    "user_type": "Providers, Patients, Government",
+    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
-        "userType": "Who are the intended users?",
-        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
-        "repositoryHost": "Where is the repository hosted?"
+        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
+        "user_type": "Who are the intended users?",
+        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
     "projectType": "{{ cookiecutter.project_type }}",
-    "userInput": "{{ cookiecutter.user_nput }}",
+    "userInput": "{{ cookiecutter.user_input }}",
     "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
     "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "userType": "{{ cookiecutter.user_ype }}",
+    "userType": "{{ cookiecutter.user_type }}",
     "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "2"
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "project_type": "{{ cookiecutter.project_type }}",
-    "user_input": "{{ cookiecutter.user_input }}",
-    "project_fisma_level": "{{ cookiecutter.project_fisma_level }}",
+    "projectType": "{{ cookiecutter.projectType }}",
+    "userInput": "{{ cookiecutter.userInput }}",
+    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
     "group": "{{ cookiecutter.group }}",
-    "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "user_type": "{{ cookiecutter.user_type }}",
-    "repository_host": "{{ cookiecutter.repository_host }}",
+    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
+    "userType": "{{ cookiecutter.userType }}",
+    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
     "maturity_model_tier": "2"
 }

--- a/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier2/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "projectType": "{{ cookiecutter.projectType }}",
-    "userInput": "{{ cookiecutter.userInput }}",
-    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
+    "projectType": "{{ cookiecutter.project_type }}",
+    "userInput": "{{ cookiecutter.user_nput }}",
+    "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
-    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
-    "userType": "{{ cookiecutter.userType }}",
-    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
-    "maturity_model_tier": "2"
+    "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
+    "userType": "{{ cookiecutter.user_ype }}",
+    "repositoryHost": "{{ cookiecutter.repository_host }}",
+    "maturityModelTier": "2"
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
+    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
     "userInput": ["Yes", "No"],
     "projectFismaLevel": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
-    "userInput": ["Yes", "No"],
-    "projectFismaLevel": ["Low", "Moderate", "High"],
+    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "user_input": ["Yes", "No"],
+    "fisma_level": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subsetInHealthcare": "Policy, Operational",
-    "userType": "Providers, Patients, Government",
-    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subset_in_healthcare": "Policy, Operational",
+    "user_type": "Providers, Patients, Government",
+    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
-        "userType": "Who are the intended users?",
-        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
-        "repositoryHost": "Where is the repository hosted?"
+        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
+        "user_type": "Who are the intended users?",
+        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
-    "user_input": ["Yes", "No"],
-    "project_fisma_level": ["Low", "Moderate", "High"],
+    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
+    "userInput": ["Yes", "No"],
+    "projectFismaLevel": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subset_in_healthcare": "Policy, Operational",
-    "user_type": "Providers, Patients, Government",
-    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subsetInHealthcare": "Policy, Operational",
+    "userType": "Providers, Patients, Government",
+    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
-        "user_type": "Who are the intended users?",
-        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?"
+        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
+        "userType": "Who are the intended users?",
+        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repositoryHost": "Where is the repository hosted?"
     }
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "project_type": "{{ cookiecutter.project_type }}",
-    "user_input": "{{ cookiecutter.user_input }}",
-    "project_fisma_level": "{{ cookiecutter.project_fisma_level }}",
+    "projectType": "{{ cookiecutter.projectType }}",
+    "userInput": "{{ cookiecutter.userInput }}",
+    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
     "group": "{{ cookiecutter.group }}",
-    "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "user_type": "{{ cookiecutter.user_type }}",
-    "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "3"
+    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
+    "userType": "{{ cookiecutter.userType }}",
+    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
+    "maturityModelTier": "3"
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "projectType": "{{ cookiecutter.projectType }}",
-    "userInput": "{{ cookiecutter.userInput }}",
-    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
+    "projectType": "{{ cookiecutter.project_type }}",
+    "userInput": "{{ cookiecutter.user_nput }}",
+    "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
-    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
-    "userType": "{{ cookiecutter.userType }}",
-    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
+    "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
+    "userType": "{{ cookiecutter.user_ype }}",
+    "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "3"
 }

--- a/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier3/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
     "projectType": "{{ cookiecutter.project_type }}",
-    "userInput": "{{ cookiecutter.user_nput }}",
+    "userInput": "{{ cookiecutter.user_input }}",
     "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
     "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "userType": "{{ cookiecutter.user_ype }}",
+    "userType": "{{ cookiecutter.user_type }}",
     "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "3"
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs"],
-    "user_input": ["Yes", "No"],
-    "project_fisma_level": ["Low", "Moderate", "High"],
+    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "userInput": ["Yes", "No"],
+    "projectFismaLevel": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subset_in_healthcare": "Policy, Operational",
-    "user_type": "Providers, Patients, Government",
-    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subsetInHealthcare": "Policy, Operational",
+    "userType": "Providers, Patients, Government",
+    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
-        "user_type": "Who are the intended users?",
-        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, etc.)",
-        "repository_host": "Where is the repository hosted?"
+        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
+        "userType": "Who are the intended users?",
+        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repositoryHost": "Where is the repository hosted?"
     }
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/cookiecutter.json
@@ -1,16 +1,16 @@
 {
-    "projectType" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
-    "userInput": ["Yes", "No"],
-    "projectFismaLevel": ["Low", "Moderate", "High"],
+    "project_type" : ["Package", "Website", "Standards", "Libraries", "Data", "Apps", "Tools", "APIs", "Docs"],
+    "user_input": ["Yes", "No"],
+    "fisma_level": ["Low", "Moderate", "High"],
     "group": "CMS/OA/DSAC",
-    "subsetInHealthcare": "Policy, Operational",
-    "userType": "Providers, Patients, Government",
-    "repositoryHost": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
+    "subset_in_healthcare": "Policy, Operational",
+    "user_type": "Providers, Patients, Government",
+    "repository_host": ["Github.com", "GitHub ENT", "GitHub Cloud", "GitLab.com", "GitLab ENT", "GitLab ENT CCSQ"],
     "__prompts__": {
         "group": "Which group is the project part of?",
-        "subsetInHealthcare": "Which subset of healthcare does the project belong to?",
-        "userType": "Who are the intended users?",
-        "userInput": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
-        "repositoryHost": "Where is the repository hosted?"
+        "subset_in_healthcare": "Which subset of healthcare does the project belong to?",
+        "user_type": "Who are the intended users?",
+        "user_input": "Does the project accept user input? (e.g. allows user to query a database, allows login by users, upload files, etc.)",
+        "repository_host": "Where is the repository hosted?"
     }
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "project_type": "{{ cookiecutter.project_type }}",
-    "user_input": "{{ cookiecutter.user_input }}",
-    "project_fisma_level": "{{ cookiecutter.project_fisma_level }}",
+    "projectType": "{{ cookiecutter.projectType }}",
+    "userInput": "{{ cookiecutter.userInput }}",
+    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
     "group": "{{ cookiecutter.group }}",
-    "subset_in_healthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "user_type": "{{ cookiecutter.user_type }}",
-    "repository_host": "{{ cookiecutter.repository_host }}",
-    "maturity_model_tier": "4"
+    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
+    "userType": "{{ cookiecutter.userType }}",
+    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
+    "maturityModelTier": "4"
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
     "projectType": "{{ cookiecutter.project_type }}",
-    "userInput": "{{ cookiecutter.user_nput }}",
+    "userInput": "{{ cookiecutter.user_input }}",
     "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
     "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
-    "userType": "{{ cookiecutter.user_ype }}",
+    "userType": "{{ cookiecutter.user_type }}",
     "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "4"
 }

--- a/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
+++ b/tier4/{{cookiecutter.project_slug}}/repometrics/{{cookiecutter.project_type}}/code.json
@@ -1,10 +1,10 @@
 {
-    "projectType": "{{ cookiecutter.projectType }}",
-    "userInput": "{{ cookiecutter.userInput }}",
-    "projectFismaLevel": "{{ cookiecutter.projectFismaLevel }}",
+    "projectType": "{{ cookiecutter.project_type }}",
+    "userInput": "{{ cookiecutter.user_nput }}",
+    "fismaLevel": "{{ cookiecutter.fisma_level }}",
     "group": "{{ cookiecutter.group }}",
-    "subsetInHealthcare": "{{ cookiecutter.subsetInHealthcare }}",
-    "userType": "{{ cookiecutter.userType }}",
-    "repositoryHost": "{{ cookiecutter.repositoryHost }}",
+    "subsetInHealthcare": "{{ cookiecutter.subset_in_healthcare }}",
+    "userType": "{{ cookiecutter.user_ype }}",
+    "repositoryHost": "{{ cookiecutter.repository_host }}",
     "maturityModelTier": "4"
 }


### PR DESCRIPTION
## Camel Case code.json Fields

## Problem

Per code.json best practices and patterns, we fields should be camel case, not snake case.

## Solution

Updated fields for cookiecutter to camel case, and updated fields in repo-scaffolder's code.json to reflect these patterns. Added `Docs` to project types.