### PR TITLE
Added a README.md to every tier

### DIFF
--- a/tier1/README.md
+++ b/tier1/README.md
@@ -25,4 +25,4 @@ There are specific files that are required and recommended to include in the rep
 | `README.md`           | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
 | `CONTRIBUTING.md`     | Recommended     | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
 
-For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].
+For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -15,7 +15,7 @@ The main purpose of a Tier 1 project is to share knowledge and provide informati
 
 ## Files for a Tier 1 Project
 
-In a Tier 1 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+There are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
 
 | **File**              | **Requirement** | **Description**                                                                                             |

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -1,0 +1,26 @@
+# Tier 1 Project: One-Time Release
+
+## What is a Tier 1 Project?
+
+A **Tier 1** project refers to an **informational or historical** project that has been **released publicly**. However, it does **not** have planned future updates or maintenance by the original authors or contributors. These projects typically include code samples, prototypes, public documentation, or other types of resources that are made available for use but won't receive ongoing updates or active development.
+
+The main purpose of a Tier 1 project is to share knowledge and provide information from past work or experiments. Though available for public consumption, the project is **not expected to evolve or expand** in the future. Contributors may not engage in continuous development or issue resolution.
+
+### Key Characteristics of a Tier 1 Project:
+- **Publicly released** without planned future development or maintenance.
+- Primarily **informational or historical** in nature.
+- May still provide value to the community, but it is not actively worked on.
+  
+---
+
+## Files for a Tier 1 Project
+
+In a Tier 1 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+
+
+| **File**              | **Requirement** | **Description**                                                                                             |
+|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
+| `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
+| `README.md`           | Mandatory       | Provides an overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `CONTRIBUTING.md`     | Recommended     | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -4,7 +4,7 @@
 
 A **Tier 1** project refers to an **informational or historical** project that has been **released publicly**. However, it does **not** have planned future updates or maintenance by the original authors or contributors. These projects typically include code samples, prototypes, public documentation, or other types of resources that are made available for use but won't receive ongoing updates or active development.
 
-The main purpose of a Tier 1 project is to share knowledge and provide information from past work or experiments. Though available for public consumption, the project is **not expected to evolve or expand** in the future. Contributors may not engage in continuous development or issue resolution.
+The main purpose of a Tier 1 project is to share knowledge and provide information from past work. Though available for public consumption, the project is **not expected to evolve or expand** in the future. Contributors may not engage in continuous development or issue resolution.
 
 ### Key Characteristics of a Tier 1 Project:
 - **Publicly released** without planned future development or maintenance.
@@ -24,3 +24,5 @@ In a Tier 1 project, there are specific files that are required, recommended, or
 | `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
 | `README.md`           | Mandatory       | Provides an overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
 | `CONTRIBUTING.md`     | Recommended     | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
+
+For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -1,4 +1,4 @@
-# Tier 1 Project: One-Time Release
+# Tier 1: One-Time Release
 
 ## What is a Tier 1 Project?
 
@@ -22,7 +22,7 @@ In a Tier 1 project, there are specific files that are required, recommended, or
 |-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
 | `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
 | `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
-| `README.md`           | Mandatory       | Provides an overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `README.md`           | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
 | `CONTRIBUTING.md`     | Recommended     | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
 
 For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -1,0 +1,32 @@
+# Tier 2: Close Collaboration
+
+## What is a Tier 2 Project?
+
+A **Tier 2** project is a **collaborative effort** that typically occurs within a team or operational division (OpDiv). The project follows an **innersource working style**, where internal teams collaborate using open source best practices but within the confines of a private or internal environment. The project is not meant for broad public contribution but rather for **internal collaboration**.
+
+Innersource projects often allow different teams within the same organization to contribute, fostering collaboration and code-sharing internally while maintaining control over external access.
+
+### Key Characteristics of a Tier 2 Project:
+- Focuses on **collaborating within a smaller team** or internal group.
+- Utilizes **innersource practices**, where internal teams work collaboratively on code, borrowing from open source workflows but keeping the work within the organization.
+- Projects may be shared among internal stakeholders or divisions.
+- **Not publicly open** to the broader community for contributions.
+
+---
+
+## Files for a Tier 2 Project
+
+In a Tier 2 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+
+| **File**              | **Requirement** | **Description**                                                                                             |
+|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
+| `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
+| `README.md`           | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `CONTRIBUTING.md`     | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
+| `MAINTAINERS.md`      | Recommended     | Lists the individuals responsible for maintaining the project as well as reviewing and approving pull requests. |
+| `CODEOWNERS.md`       | Recommended     | Defines ownership of various sections of the repository. |
+| `COMMUNITY_GUIDELINES.md` | Mandatory   | Outlines how team members should engage with each other while working on the project, including behavior expectations for internal contributors. |
+| `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for professional and respectful behavior to foster a collaborative environment. |
+
+For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -29,4 +29,4 @@ There are specific files that are required and recommended to include in the rep
 | `COMMUNITY_GUIDELINES.md` | Mandatory   | Outlines how team members should engage with each other while working on the project, including behavior expectations for internal contributors. |
 | `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for professional and respectful behavior to foster a collaborative environment. |
 
-For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].
+For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -16,7 +16,7 @@ Innersource projects often allow different teams within the same organization to
 
 ## Files for a Tier 2 Project
 
-In a Tier 2 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+There are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
 | **File**              | **Requirement** | **Description**                                                                                             |
 |-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -10,7 +10,7 @@ Innersource projects often allow different teams within the same organization to
 - Focuses on **collaborating within a smaller team** or internal group.
 - Utilizes **innersource practices**, where internal teams work collaboratively on code, borrowing from open source workflows but keeping the work within the organization.
 - Projects may be shared among internal stakeholders or divisions.
-- **Not publicly open** to the broader community for contributions.
+- **Not necessarily accepting contributions** from the broader community.
 
 ---
 

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -29,4 +29,4 @@ There are specific files that are required and recommended to include in the rep
 | `COMMUNITY_GUIDELINES.md` | Mandatory   | Defines expectations for interactions within the project's community, including how external contributors should engage and behave. |
 | `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
 
-For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].
+For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -6,7 +6,7 @@ A **Tier 3** project is an **open collaboration** effort where the work is condu
 
 ### Key Characteristics of a Tier 3 Project:
 - **Collaborative in public**, where the work is open to external stakeholders.
-- Led by a **semi-open team** (often organizational or tool-specific).
+- Led by a **CMS team** (often organizational or tool-specific).
 - Accepts **limited contributions from external sources**, typically following specific guidelines.
 - Publicly accessible code and documentation.
 - Maintenance and decision-making are generally led by CMS.

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -1,0 +1,32 @@
+# Tier 3: Working in Public
+
+## What is a Tier 3 Project?
+
+A **Tier 3** project is an **open collaboration** effort where the work is conducted in public. The project is led by smaller, semi-open teams but encourages **limited external contributions**. The work is typically **open source**, but the direction and maintenance of the project are CMS-led, controlled by a smaller group or team, rather than a large, decentralized community. Tier 3 projects may be public-facing tools, utilities, or websites, where external contributions are welcomed but managed closely by the core team.
+
+### Key Characteristics of a Tier 3 Project:
+- **Collaborative in public**, where the work is open to external stakeholders.
+- Led by a **semi-open team** (often organizational or tool-specific).
+- Accepts **limited contributions from external sources**, typically following specific guidelines.
+- Publicly accessible code and documentation.
+- Maintenance and decision-making are generally led by CMS.
+
+---
+
+## Files for a Tier 3 Project
+
+In a Tier 3 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+
+| **File**              | **Requirement** | **Description**                                                                                             |
+|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
+| `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
+| `README.md`           | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `CONTRIBUTING.md`     | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
+| `MAINTAINERS.md`      | Recommended     | Lists the individuals responsible for maintaining the project as well as reviewing and approving pull requests. |
+| `GOVERNANCE.md`       | Recommended     | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project. |
+| `CODEOWNERS.md`       | Recommended     | Defines ownership of various sections of the repository. |
+| `COMMUNITY_GUIDELINES.md` | Mandatory   | Defines expectations for interactions within the project's community, including how external contributors should engage and behave. |
+| `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
+
+For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -15,7 +15,7 @@ A **Tier 3** project is an **open collaboration** effort where the work is condu
 
 ## Files for a Tier 3 Project
 
-In a Tier 3 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+There are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
 | **File**              | **Requirement** | **Description**                                                                                             |
 |-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|

--- a/tier4/README.md
+++ b/tier4/README.md
@@ -1,0 +1,30 @@
+# Tier 4: Community Governance
+
+## What is a Tier 4 Project?
+
+A **Tier 4** project is a fully **open and collaborative** project that operates under a **community governance model**. In Tier 4 projects, the focus is on **collaborating broadly with the public**, and the project is often either **donated** to or **stewarded** by an external community. The governance structure is **open** and welcomes input from a wide range of contributors, typically from outside the original development team.
+
+### Key Characteristics of a Tier 4 Project:
+- **Broad public collaboration** with contributions welcomed from the community.
+- **Community-led governance**, where decisions are made transparently, often with input from various stakeholders.
+- **Mature open-source project**, typically with a well-defined governance structure to guide development, maintenance, and project direction.
+
+---
+
+## Files for a Tier 4 Project
+
+In a Tier 4 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+
+| **File**              | **Requirement** | **Description**                                                                                             |
+|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
+| `SECURITY.md`         | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
+| `README.md`           | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `CONTRIBUTING.md`     | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests. |
+| `MAINTAINERS.md`      | Mandatory     | Lists the individuals responsible for maintaining the project as well as reviewing and approving pull requests. |
+| `GOVERNANCE.md`       | Mandatory     | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project. |
+| `CODEOWNERS.md`       | Mandatory     | Defines ownership of various sections of the repository. |
+| `COMMUNITY_GUIDELINES.md` | Mandatory   | Defines expectations for interactions within the project's community, including how external contributors should engage and behave. |
+| `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
+
+For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].

--- a/tier4/README.md
+++ b/tier4/README.md
@@ -13,7 +13,7 @@ A **Tier 4** project is a fully **open and collaborative** project that operates
 
 ## Files for a Tier 4 Project
 
-In a Tier 4 project, there are specific files that are required, recommended, or not recommended as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+There are specific files that are required to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
 | **File**              | **Requirement** | **Description**                                                                                             |
 |-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|

--- a/tier4/README.md
+++ b/tier4/README.md
@@ -27,4 +27,4 @@ There are specific files that are required to include in the repository as part 
 | `COMMUNITY_GUIDELINES.md` | Mandatory   | Defines expectations for interactions within the project's community, including how external contributors should engage and behave. |
 | `CODE_OF_CONDUCT.md`  | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
 
-For more information about required sections and content within the files above, please visit (maturity-model-tiers.md)[https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md].
+For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).


### PR DESCRIPTION
## Problem
As we work on the CMS Open Source Policy, we are looking to link to some sections of `repo-scaffolder` to it. Currently, our only document that explains the maturity model tiers is `maturity-model-tiers.md` and it does so in a brief way. We would like to improve documentation on the maturity model framework so users have a clear idea on the characteristics and differences of the tiers.

## Solution
Created a README.md to every tier that includes:
- Description of maturity model tier
- List of important characteristics
- Table with required and recommended files