### PR TITLE
Workflows: Fixes to `autochangelog.yml` workflow files in tiers 2-4

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -10,4 +10,6 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{ secrets.GITHUB_TOKEN }}
+          {% endraw %}

--- a/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -205,7 +205,9 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          {% endraw %}
 ```
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release. 
 

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -10,4 +10,6 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{ secrets.GITHUB_TOKEN }}
+          {% endraw %}

--- a/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -214,7 +214,9 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          {% endraw %}
 ```
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release. 
 

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -10,4 +10,6 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{ secrets.GITHUB_TOKEN }}
+          {% endraw %}

--- a/tier4/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier4/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -216,7 +216,9 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
+          {% raw %}
           token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          {% endraw %}
 ```
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release. 
 


### PR DESCRIPTION
## Workflows: Fixes to `autochangelog.yml` and `MAINTAINER.md` files in tiers 2-4

## Problem
When generating Tier 2-4 projects using cookiecutter, this error occurs:
<img width="608" alt="Screenshot 2024-10-04 at 2 25 03 PM" src="https://github.com/user-attachments/assets/70780781-97f8-4f6f-a8a4-f2b90921877b">


## Solution
Added raw tags to the workflow and `MAINTAINERS.md` files

Solution is similar to https://github.com/DSACMS/repo-scaffolder/pull/99.

## Result
Running cookiecutter on tiers 2-4 now exit cleanly without an error.

## Test Plan
`cookiecutter . --directory=X` where X = 2, 3, 4
