### PR TITLE
Update release-guidelines-template.md to Add Credit

### DIFF
--- a/release-guidelines-template.md
+++ b/release-guidelines-template.md
@@ -236,5 +236,7 @@ In rare cases, a hotfix for a prior release may be required out-of-phase with th
 
 [proj-releases-new]: https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/releases/new
 
+[Inspiration for this document](https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md)
+
 
 


### PR DESCRIPTION


## Update release-guidelines-template.md to Add Credit

## Problem

We currently do not credit the source of where we got the structure of our release documentation. Our release documentation is a heavily altered version of the one found in the openmobilityfoundaiton's governance repo: https://github.com/openmobilityfoundation/governance/blob/main/technical/ReleaseGuidelines.md

## Solution

Credit the inspiration for the format, layout, and general structure of our release guidance documentation.

## Result

I have added a link to the release documentation that I used as an inspiration to write the release documentation found in this repository. 

