### PR TITLE
Fix Markdown Links in Release Guidance Documentation 

### DIFF
--- a/release-guidelines-template.md
+++ b/release-guidelines-template.md
@@ -118,7 +118,7 @@ The following steps outline the process to prepare a Release Candidate of {{ coo
 	git push --tags
 	```
 
-3. Publish a [pre-Release in GitHub][proj-releases-new]:
+3. Publish a [pre-Release in GitHub](proj-releases-new):
 
 	```md
 	Tag version: [tag you just pushed]

--- a/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier2/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -137,7 +137,7 @@ The following steps outline the process to prepare a Release Candidate of {{ coo
     git push --tags
     ```
 
-3. Publish a [pre-Release in GitHub][proj-releases-new]:
+3. Publish a [pre-Release in GitHub](proj-releases-new):
 
     ```md
     Tag version: [tag you just pushed]

--- a/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier3/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -146,7 +146,7 @@ The following steps outline the process to prepare a Release Candidate of {{ coo
     git push --tags
     ```
 
-3. Publish a [pre-Release in GitHub][proj-releases-new]:
+3. Publish a [pre-Release in GitHub](proj-releases-new):
 
     ```md
     Tag version: [tag you just pushed]

--- a/tier4/{{cookiecutter.project_slug}}/MAINTAINERS.md
+++ b/tier4/{{cookiecutter.project_slug}}/MAINTAINERS.md
@@ -148,7 +148,7 @@ The following steps outline the process to prepare a Release Candidate of {{ coo
     git push --tags
     ```
 
-3. Publish a [pre-Release in GitHub][proj-releases-new]:
+3. Publish a [pre-Release in GitHub](proj-releases-new):
 
     ```md
     Tag version: [tag you just pushed]


### PR DESCRIPTION
## Fix Markdown Links in Release Guidance Documentation 

## Problem

There are some links in the release guidance docs that have links in the format [text][url] instead of the proper [text](url).

## Solution

Fix the issue by formatting the links correctly. 

