### PR TITLE
Fixed the dateCreated Bug

### DIFF
--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -29,7 +29,7 @@ def addTopic():
 
 subprocess.call(["git", "init", "-b", "main"])
 subprocess.call(["git", "add", "."])
-subprocess.call(["git", "commit", "-m", "inital commit"])
+subprocess.call(["git", "commit", "-m", "initial commit"])
 
 if CREATE_REPO == "True":
     createGithubRepo()

--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -8,9 +8,6 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
 
 def createGithubRepo():
-    subprocess.call(["git", "init", "-b", "main"])
-    subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "first commit"])
     gh_cli_command = [
         "gh", "repo", "create",
         f"{ORG_NAME}/{REPO_NAME}",
@@ -29,6 +26,10 @@ def addTopic():
         "--add-topic=dsacms-tier0",
     ]
     subprocess.call(gh_cli_command)
+
+subprocess.call(["git", "init", "-b", "main"])
+subprocess.call(["git", "add", "."])
+subprocess.call(["git", "commit", "-m", "created repository"])
 
 if CREATE_REPO == "True":
     createGithubRepo()

--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -29,7 +29,7 @@ def addTopic():
 
 subprocess.call(["git", "init", "-b", "main"])
 subprocess.call(["git", "add", "."])
-subprocess.call(["git", "commit", "-m", "created repository"])
+subprocess.call(["git", "commit", "-m", "inital commit"])
 
 if CREATE_REPO == "True":
     createGithubRepo()

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -42,7 +42,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "created repository"])
+    subprocess.call(["git", "commit", "-m", "inital commit"])
     
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -10,9 +10,6 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
 
 def createGithubRepo():
-    subprocess.call(["git", "init", "-b", "main"])
-    subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "first commit"])
     gh_cli_command = [
         "gh", "repo", "create",
         f"{ORG_NAME}/{REPO_NAME}",
@@ -43,6 +40,10 @@ def moveCookiecutterFile():
     shutil.move(source_path, destination_path)
 
 def main():
+    subprocess.call(["git", "init", "-b", "main"])
+    subprocess.call(["git", "add", "."])
+    subprocess.call(["git", "commit", "-m", "created repository"])
+    
     if CREATE_REPO == "True":
         createGithubRepo()
 

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -42,7 +42,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "inital commit"])
+    subprocess.call(["git", "commit", "-m", "initial commit"])
     
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -83,7 +83,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "created repository"])
+    subprocess.call(["git", "commit", "-m", "inital commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -11,9 +11,6 @@ RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
-    subprocess.call(["git", "init", "-b", "main"])
-    subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "first commit"])
     gh_cli_command = [
         "gh", "repo", "create",
         f"{ORG_NAME}/{REPO_NAME}",
@@ -84,6 +81,10 @@ def moveCookiecutterFile():
     shutil.move(source_path, destination_path)
 
 def main():
+    subprocess.call(["git", "init", "-b", "main"])
+    subprocess.call(["git", "add", "."])
+    subprocess.call(["git", "commit", "-m", "created repository"])
+
     if CREATE_REPO == "True":
         createGithubRepo()
 

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -83,7 +83,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "inital commit"])
+    subprocess.call(["git", "commit", "-m", "initial commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "inital commit"])
+    subprocess.call(["git", "commit", "-m", "initial commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -11,9 +11,6 @@ RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
-    subprocess.call(["git", "init", "-b", "main"])
-    subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "first commit"])
     gh_cli_command = [
         "gh", "repo", "create",
         f"{ORG_NAME}/{REPO_NAME}",
@@ -77,6 +74,10 @@ def moveCookiecutterFile():
     shutil.move(source_path, destination_path)
 
 def main():
+    subprocess.call(["git", "init", "-b", "main"])
+    subprocess.call(["git", "add", "."])
+    subprocess.call(["git", "commit", "-m", "created repository"])
+
     if CREATE_REPO == "True":
         createGithubRepo()
 

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "created repository"])
+    subprocess.call(["git", "commit", "-m", "inital commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "inital commit"])
+    subprocess.call(["git", "commit", "-m", "initial commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -11,9 +11,6 @@ RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
-    subprocess.call(["git", "init", "-b", "main"])
-    subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "first commit"])
     gh_cli_command = [
         "gh", "repo", "create",
         f"{ORG_NAME}/{REPO_NAME}",
@@ -77,6 +74,10 @@ def moveCookiecutterFile():
     shutil.move(source_path, destination_path)
 
 def main():
+    subprocess.call(["git", "init", "-b", "main"])
+    subprocess.call(["git", "add", "."])
+    subprocess.call(["git", "commit", "-m", "created repository"])
+
     if CREATE_REPO == "True":
         createGithubRepo()
 

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -76,7 +76,7 @@ def moveCookiecutterFile():
 def main():
     subprocess.call(["git", "init", "-b", "main"])
     subprocess.call(["git", "add", "."])
-    subprocess.call(["git", "commit", "-m", "created repository"])
+    subprocess.call(["git", "commit", "-m", "inital commit"])
 
     if CREATE_REPO == "True":
         createGithubRepo()


### PR DESCRIPTION
## Fixed the dateCreated Bug

## Problem

When I use repo-scaffolder to create a fresh new repository and then use the cookiecutter command to create the repo's code.json file, the "created" field in the date object is incorrect.

## Solution

Create a .git directory whenever each cookiecutter is run by default.

## Result

The date object within code.json is correct.

Some important notes regarding the summary line:

* Language for the commit message for the first commit might need to change to fit the changelog language.
* Related to #181 

## Test Plan

Tested locally
