### PR TITLE
Docs: Adding Reviewing Project Metadata section to all checklists + clean up

### DIFF
--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -82,16 +82,14 @@ This is a review process to approve CMS-developed software to be released open s
 ### Questions
 
 - Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?
-  - What PII or PHI does this project contain?
+  - Can it be removed? Is it absolutely needed to function? Can it be shipped with synthetic data instead?
 
 - Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?
-  - What processes do you go through internally to get access to the systems?
 
 - Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?
+  - Can it be removed or is it needed?
 
-- Does this repository require any job codes to run?
-
-If you answered “yes” to any of the above questions, your project may be ‘sensitive’ in nature and require a more thorough review before sharing publicly. Please reach out to [opensource@cms.hhs.gov](mailto:opensource@cms.hhs.gov) for guidance. If you answer yes to any of these questions above, it is best to NOT open source the product due to security reasons.
+If you answered “yes” to any of the above questions, your project may be ‘sensitive’ in nature, and require a more thorough review before sharing publicly. Please reach out to opensource@cms.hhs.gov for guidance. If you answer yes to any of these questions above, it is best to seek guidance _before_ releasing open source.
 
 #### Results
 *Insert Review Here*

--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -255,7 +255,7 @@ _Contains metadata about the project, refer to [Review Project Metadata](#review
 
 
 
-## Review Project Metadata
+### Review Project Metadata
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**

--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -23,6 +23,8 @@ This is a review process to approve CMS-developed software to be released open s
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Project Metadata](#review-project-metadata)
+
 [Review Repository Details](#review-repository-details)
 
 [Additional Notes & Questions](#additional-notes--questions)
@@ -230,7 +232,7 @@ repolinter lint .
 *License of your project, whether public domain (CC0) or other OSI-approved License. Using 'vanilla' license text will allow for GitHub to auto-label the license information on the repository landing page.*
 
 - [ ] **CONTRIBUTING.md**
-*Provide guidance on how users can run your project and make contributions to it.*
+*Provides guidance on how users can run your project and make contributions to it.*
 
 | **Section**           | **Description**                                                                                                                                                                                                                                                                                     | **Included** |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
@@ -244,9 +246,35 @@ repolinter lint .
 - [ ] **repolinter.json**
 _Lints repository for missing files and sections above_
 
+- [ ] **code.json**
+_Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)_
+
 **Results**
 
 *Insert Review Here*
+
+
+
+## Review Project Metadata
+As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
+
+**Creating code.json on your repository**
+1. In the `.github` directory, run the command: 
+  ```
+  cookiecutter . –directory=codejson
+  ```
+
+2. Answer various questions about your project.
+
+3. A code.json file will be generated with your responses.
+
+Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
+
+**Results**
+
+*Insert Review Here*
+
+
 
 
 ### Review Repository Details

--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -1,4 +1,4 @@
-# DSAC OSPO Outbound Review Checklist
+# CMS OSPO Outbound Review Checklist
 ## Tier 1: One-Time Release
 
 ### Instructions
@@ -33,54 +33,68 @@ This is a review process to approve CMS-developed software to be released open s
 
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
 
+
+
 ### State the Benefits of Open Sourcing the Project
 
-- [ ] **Cost Savings** 
-by making the project freely available, this reduces licensing and acquisition costs.
+- [ ] **Cost Savings**
+
+    By making the project freely available, this reduces licensing and acquisition costs.
+
 - [ ] **Ease of Repurposing**
-The open nature of the code allows users to modify and adapt the software to suit their specific needs, fostering customization and flexibility.
+
+    The open nature of the code allows users to modify and adapt the software to suit their specific needs, fostering customization and flexibility.
+
 - [ ] **Minimization of Vendor Lock-in/Flexibility of Vendor Choice**
-Users are not tied to a single vendor, providing the freedom to choose between different vendors.
+
+    Users are not tied to a single vendor, providing the freedom to choose between different vendors.
+
 - [ ] **Enable Transparency**
-The source code is accessible and visible to anyone, promoting transparency in how the software functions, which helps build trust.
-- [ ] **Enable Extension/Extensibility**
-Users can extend and enhance the functionality of the software by adding their own features.
+
+    The source code is accessible and visible to anyone, promoting transparency in how the software functions, which helps build trust.
+
+- [ ] **Enable extension/extensibility**
+
+    Users can extend and enhance the functionality of the software by adding their own features.
+
 - [ ] **Increase Interoperability**
-Planning in the open enables future compatibility and interoperability between different systems and software applications.
+
+    Planning in the open enables future compatibility and interoperability between different systems and software applications.
+
 - [ ] **Facilitate Experimentation/Early Adoption**
-Working in the open encourages experimentation and early adoption of cutting-edge technologies,leading to faster innovation and improvemnet in software capabilities.
+
+    Working in the open encourages experimentation and early adoption of cutting-edge technologies, leading to faster innovation and improvement in software capabilities.
 
 ### State the Risks of Open Sourcing the Project
 
 - [ ] **Security Risks**
-Vulnerabilities may be exposed if the code is not thoroughly reviewed, potentially leading to security breaches or exploitation.(See: [Security.md](https://github.com/DSACMS/repo-scaffolder/blob/main/SECURITY.md))Does this project connect to any CMS-internal only systems? Does this project require authorization or authentication to operate? Does this project detail any non-public directories of CMS/HHS systems or people?
-- [ ] **Financial Risks**
-Costs may arise from maintaining code, community engagemnet, addressing security concerns, or subscription costs, hardware costs, specialized tooling or infrastructure costs, among others. Does this project require any ongoing financial costs or subscription fees?
-(e.g. - Cloud Hosting, Specialized build systems, paid maintainers, paid libraries or dependencies.)
-- [ ] **Privacy Risks**
-Does this project require access to non-public, non synthetic PII, PHI, or other internal-only CMS Systems containing such data or information?
 
----
+    Vulnerabilities may be exposed if the code is not thoroughly reviewed, potentially leading to security breaches or exploitation. (See: [SECURITY.md]({{cookiecutter.project_slug}}/SECURITY.md)) Does this project connect to any CMS-internal only systems? Does this project require authorization or authentication to operate? Does this project detail any non-public directories of CMS/HHS systems or people?
+
+- [ ] **Financial Risks**
+
+    Costs may arise from maintaining code, community engagement, addressing security concerns, subscription costs, hardware costs, specialized tooling or infrastructure costs among others. Does this project require any ongoing financial costs or subscription fees? (e.g., Cloud Hosting, Specialized build systems, paid maintainers, paid libraries or dependencies.)
+
+- [ ] **Privacy Risks**
+
+    Does this project require access to non-public, non-synthetic PII, PHI, or other internal-only CMS systems containing such data or information?
 
 ### Questions
 
 - Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?
-  - Can it be removed? Is it absolutely needed to function? Can it be shipped with synthetic data instead?
- - Does the code interface with any CMS' internal-only systems(e.g. mainframes, JIRA instances, databases, etc...)?
- - Does the repository contain any keys or credentials to access or authenticate with CMS' systems?
-   - Can it be removed or is it needed?
+  - What PII or PHI does this project contain?
 
-   If you answered "yes" to any of the above questions, your project may be 'sensitive' in nature, and requires a more thorough review before sharing publicly. Please reach out to opensource@cms.hhs.gov for guidance. If you answer yes to any of these questions above, it is best to seek quidance **before** releasing open source.
+- Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?
+  - What processes do you go through internally to get access to the systems?
 
- **Results** 
- *Insert Review Here*
+- Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?
 
+- Does this repository require any job codes to run?
 
+If you answered “yes” to any of the above questions, your project may be ‘sensitive’ in nature and require a more thorough review before sharing publicly. Please reach out to [opensource@cms.hhs.gov](mailto:opensource@cms.hhs.gov) for guidance. If you answer yes to any of these questions above, it is best to NOT open source the product due to security reasons.
 
-
-   
-
-
+#### Results
+*Insert Review Here*
 
 
 ### Code Review
@@ -91,17 +105,10 @@ The engineers can be federal government employees or trusted partners from outsi
 
 To provide independent review, ideally the engineers should not have been involved in the development of the software product. This includes engineers who wrote part of the software or who directly provided technical direction and oversight in the creation of the software.
 
-As part of the code review, engineers should reference modern listings of the most significant software security vulnerabilities. For instance, an acceptable description would be that the engineers showed how they used automated tools and manual review to check each item in __OWASP's current 10 Most Critical Web Application Security Risks.__
+As part of the code review, engineers should reference modern listings of the most significant software security vulnerabilities. For instance, an acceptable description would be that the engineers showed how they used automated tools and manual review to check each item in [OWASP's current 10 Most Critical Web Application Security Risks](https://owasp.org/www-project-top-ten/).
 
-
-
-
-   **Results**
-
-   *Insert Review Here*
-
-
-   
+#### Results
+*Insert Review Here*
 
 
 ### Code Analysis 
@@ -114,35 +121,32 @@ Ideally, automated tooling for code analysis should be incorporated as a regular
 #### Toolkit
    Below is a list of suggested tools to run for code analysis:
 
-| **Tool** |  **Description** |  **Link**   |
+| Tool |  Description |  Link   |
 :-------| :-------------: | :------: |
 | Repo Linter  | Lint repositories for common issues such as missing files etc.| https://github.com/todogroup/repolinter |
 |  gitleaks  | Protect and discover secrets using Gitleaks :key:  |  https://github.com/gitleaks/gitleaks
 | git filter-repo |  Entirely remove unwanted files / files with sensitive data from a repository's history   |  https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository
 
-
-**Results**
-
+#### Results
 *Insert Review Here*
-
 
 
 ### Review Licensing
 
-Ensure that acceptable licensing is indicated for the project. Most often, software released as open source by the federal government is done so under the Creative Commons Zero 1.0 license.
+Ensure that acceptable licensing is decided for the project. Most often, software released as open source by the federal government does so under the Creative Commons Zero 1.0
+license.
 
 Suggested licensing:
 
-   **Public Domain**
-   
-  - This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
+ **Public Domain**
 
-  - All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+  This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
+
+  All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
 
 If your project is not being dedicated to the public domain under CC0, due to being work for hire, or some other documented reason, then choosing another [OSI approved license](https://opensource.org/license) is the next best thing.
 
-**Results**
-
+#### Results
 *Insert Review Here*
 
 
@@ -152,55 +156,38 @@ If your project is not being dedicated to the public domain under CC0, due to be
 Review the history of commits to the version control system used, and whether the team prefers to clean (e.g.,rebase) this history before releasing to the public.
 
 If not rebasing, verify that:
-
 1. There are no obscene or impolite remarks in comments or commit history
-
 2. There are no sensitive internal URLs/IP addresses in comments or commit history 
-
 3. There are no credential files such as passwords, API/SSH/GPG keys checked into the repo
 
 Consider using the following tools to perform the tasks above:
-
-[^1]: Table needs work - [x] 
 
 | Tool        | Description                                                      | Link                                    |
 |-------------|------------------------------------------------------------------|-----------------------------------------|
 | gitleaks | Open source tool that detects and prevents secrets (passwords/api/ssh keys) checked-in to your git repo | https://github.com/gitleaks/gitleaks   https://akachandwani.medium.com/what-is-gitleaks-and-how-to-use-it-a05f2fb5b034 |
 | git filter-repo    | Entirely remove unwanted files / files with sensitive data from a repository's history                     |    https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository                   |
 
-**Results**
-
+#### Results
 *Insert Review Here*
 
 
 
-
 ### Review Repository Hygiene
-
 As part of our repository hygiene requirements, the project must include certain files and sections. Using repolinter will help identify missing files and content that will need to be added to your repository before outbounding.
 
-**Running repolinter on your repository**
-
-[^1]: the repolinter.json seems like some sort of link to something
-
-
-
+#### Running repolinter on your repository locally
 1. Add [repolinter.json](https://github.com/DSACMS/repo-scaffolder/blob/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json) to the root directory of your project
 
-[^1]: that command is highlighted green could also think to something? - [x]
-
-2. Run command 
+2. Run command: 
 ```
 repolinter lint .
 ```
+
 3. The result produces a list of files section existence checks, indicating whether each requirement was met or not.
-
-
 
 ![repolinter results](../assets/repolinter-results.png)
 
-**Running repolinter on your repository via GitHub Actions**
-
+#### Running repolinter on your repository via GitHub Actions
 1. Add the tier-specific [checks.yml](https://github.com/DSACMS/repo-scaffolder/blob/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml) to the github directory of your project. The file includes a job that runs a repolinter called [repolinter-checks](https://github.com/DSACMS/repo-scaffolder/blob/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml#L13)
 
 2. Manually trigger the workflow
@@ -213,12 +200,11 @@ repolinter lint .
  The project should include the following files and sections [(link to template)](https://github.com/DSACMS/repo-scaffolder/tree/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D):
 
  - [ ] **README.md**
-    _An essential guide that gives viewers a detailed description of your project_
+
+     *An essential guide that gives viewers a detailed description of your project*
 
 
-
-
-| **Section**         | **Description**                                                                                                                                                                                                                                                                                | **Included** |
+| Section        |Description                                                                                                                                                                                                                                                                                | Included |
 |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
 | Project Description | 1-3 sentences short description of the project that can be used as a 'one-liner' to describe the repo. A best practice is using this same language as the official 'description' on GitHub repo landing page.                                                                                  |    :white_check_mark: :x:          |
 | About the Project   | Longer-form description of the project. It can include history, background, details, problem statements, links to design documents or other supporting materials, or any other information/context that a user or contributor might be interested in.                                             |              |
@@ -229,12 +215,15 @@ repolinter lint .
 
 - [ ] **LICENSE**
 
-*License of your project, whether public domain (CC0) or other OSI-approved License. Using 'vanilla' license text will allow for GitHub to auto-label the license information on the repository landing page.*
+    *License of your project, whether public domain (CC0) or other OSI-approved License. Using
+    ‘vanilla’ license text will allow for GitHub to auto-label the license information on the
+    repository landing page.*
 
 - [ ] **CONTRIBUTING.md**
-*Provides guidance on how users can run your project and make contributions to it.*
 
-| **Section**           | **Description**                                                                                                                                                                                                                                                                                     | **Included** |
+    *Provides guidance on how users can run your project and make contributions to it*
+
+| Section           | Description                                                                                                                                                                                                                                                                                     | Included |
 |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|
 | Getting Started       | Included installations steps, prerequisites for installation, and instructions for working with the source code                                                                                                                                                                                     |              |
 | Building Dependencies | This step is often skipped, so don't forget to include the steps needed to install on your platform. If your project can be multi-platform, this is an excellent place for first time contributors to send patches!                                                                                 |              |
@@ -244,18 +233,20 @@ repolinter lint .
 | Public Domain         | This section is to explicitly link to Federal policies and guidelines that required or recommended for Federal projects to comply with, such as Accessibility (508) Interoperability, Anti-deficiency, Security, Licensing, and other policies that can vary between agencies and domains.          |              |
 
 - [ ] **repolinter.json**
-_Lints repository for missing files and sections above_
+
+    *Lints repository for missing files and sections above*
 
 - [ ] **code.json**
-_Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)_
 
-**Results**
+    *Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)*
 
+#### Results
 *Insert Review Here*
 
 
 
 ### Review Project Metadata
+
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**
@@ -270,43 +261,44 @@ As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov
 
 Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
 
-**Results**
-
+#### Results
 *Insert Review Here*
-
-
 
 
 ### Review Repository Details
 
-The GitHub repository homepage features a concise description of the project, a list of relevant topic tags, and general information about the repository to provide a comprehensive overview for users and contributors.
+The GitHub repository homepage features a concise description of the project, a list of
+relevant topic tags, and general information about the repository to provide a
+comprehensive overview for users and contributors.
 
-_About Section_
-- [ ] **Description**
-1-2 sentences describing the project
+**About Section:**
 
-- [ ] **Website**
-Link to project's website
+- [ ] Description
+ 
+    *1-2 sentences describing the project*
 
-- [ ] **Topics**
-Tags for project discoverability. Helpful topics to classify a repository include the repository's intended purpose, subject area, community, or language.
+- [ ] Website
 
-_Include in Home Page_:
+    *Link to project’s website*
 
+- [ ] Topics
+
+    *Tags for project discoverability. Helpful topics to classify a repository include the
+        repository's intended purpose, subject area, community, or language.*
+
+**Include in Home Page:**
 - [ ] Releases
 - [ ] Packages
 - [ ] Deployments
 
-
-
-**Results**
-
+#### Results
 *Insert Review Here*
 
 
-### Additional Notes & Questions
 
+### Additional Notes & Questions
 *Insert any notes or questions here*
+
 
 
 ### Sign off on risk acceptance of open-sourcing the software product
@@ -317,7 +309,7 @@ After reviewing the materials prepared by the team that is working to open sourc
 Requesting sign off from key people on this request.
 
 
-| **Reviewer Organization**      | **Reviewer Name**                                  | Reviewer's Recommendation**                                                     |
+| Reviewer Organization      | Reviewer Name                                  | Reviewer's Recommendation                                                     |
 |--------------------------------|----------------------------------------------------|---------------------------------------------------------------------------------|
 | Code Reviewer's Recommendation | CODE REVIEWER 1  CODE REVIEWER 2   CODE REVIEWER 3 | [Approved/Needs Approval]  [Approved/Needs Approval]  [Approved/Needs Approval] |
 | ISSO                           | ISSO REVIEWER                                      | [Approved/Needs Approval]                                                       |
@@ -329,32 +321,36 @@ Requesting sign off from key people on this request.
 
 Once the repository has passed outbound review, we are ready “flip the switch” and officially make it public. Once made public, there are a couple of actions that need to be taken: 
 
-*Repository Actions* 
+#### Repository Actions
 
-Please enable the following features to enhance repository security and maintain code quality:
+Please enable the following features to enhance repository security and maintain code
+quality:
 
 - [ ] **Dependabot Alerts**
-A GitHub Feature. Get notified when one of your dependencies has a vulnerability
+
+    *A GitHub Feature. Get notified when one of your dependencies has a vulnerability*
 
 - [ ] **Secret Scanning Alerts**
-A GitHub Feature. Get notified when a secret is pushed to this repository. Ideally set this up to run after each new commit is pushed to the repository
 
-- [ ] **Branch Protection**
-Ensures the Integrity of important branches by preventing unauthorized actions like force pushes and requiring pull request reviews with specific checks before merging. Dev and main should be protected branches in the repository.
+    *A GitHub Feature. Get notified when a secret is pushed to this repository. Ideally set this up to run after each new commit is pushed to the Repository.*
+
+- [ ] **Branch Protections**
+
+    *Ensures the integrity of important branches by preventing unauthorized actions like force pushes and requiring pull request reviews with specific checks before merging. Dev and main should be protected branches in the repository.*
 
 - [ ] **Git Branching**
-After making the repository public, make sure there is a coherent git branching pla in place. For example: agree to merge features related pull requests into dev but merge bug fixes into main instead of dev first.
 
-[^1]: theres a couple of links
+    *After making the repository public, make sure there is a coherent git branching plan in place. For example: agree to merge feature related pull requests into dev but merge bug fixes into main instead of dev first.*
 
 - [ ] **Add Repolinter GH Action to CI**
-For ongoing adherence to repository hygiene standards, integrate the [repolinter Github Action](https://github.com/DSACMS/metrics/blob/main/.github/workflows/checks.yml) into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.
+
+    *For ongoing adherence to repository hygiene standards, integrate the [repolinter GitHub Action](https://github.com/DSACMS/metrics/blob/main/.github/workflows/checks.yml) into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.*
 
 - [ ] **Optional: DCO (Developer Certificate of Origin)**
-Requires all commit messages to contain the <span style="color:green"><i>Signed-off-by</i></span> line with an email address that matches the commit author. The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. The GitHub app to enforce DCO can be found [here](https://github.com/apps/dco) 
 
-_Communications & Rollout :mega:_
+    *Requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author. The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. The GitHub app to enforce DCO can be found [here](https://github.com/apps/dco) .*
 
+#### Communications & Rollout 📣
 
 Share the good news with communities both inside and outside CMS!
 
@@ -381,16 +377,10 @@ Be sure to include the following information:
 
 - [ ] **Add launch announcement to a Confluence Wiki Page**
 
-*Tracking* :chart_with_upwards_trend:
+#### Tracking 📈
 
 Add your project to our inventories.
 
 - [ ] **Add to https://github.com/dsacms/open projects inventory**
 
 - [ ] **Add code.json to repository and sent over a pull request to [code.gov](https://code.gov/)**
-
-
-
-
-
-

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -1,6 +1,8 @@
 # CMS OSPO Outbound Review Checklist
 ## Tier 2: Close Collaboration
+
 ### Instructions
+
 This is a review process to approve CMS-developed software to be released open source at [github.cms.gov](https://github.cms.gov/).
 If you would like your repository to be released, please complete the following steps.
 
@@ -34,8 +36,6 @@ If you would like your repository to be released, please complete the following 
 
 
 
-
-
 ### State the Benefits of Open Sourcing the Project
 
 - [ ] **Cost Savings**
@@ -66,9 +66,6 @@ If you would like your repository to be released, please complete the following 
 
     Working in the open encourages experimentation and early adoption of cutting-edge technologies, leading to faster innovation and improvement in software capabilities.
 
-
-
-
 ### State the Risks of Open Sourcing the Project
 
 - [ ] **Security Risks**
@@ -82,9 +79,6 @@ If you would like your repository to be released, please complete the following 
 - [ ] **Privacy Risks**
 
     Does this project require access to non-public, non-synthetic PII, PHI, or other internal-only CMS systems containing such data or information?
-
-
-
 
 ### Questions
 
@@ -105,8 +99,8 @@ If you answered “yes” to any of the above questions, your project may be ‘
 
 
 
-
 ### Code Review
+
 The existing codebase should be given a one time, top-to-bottom code quality and security vulnerability review by two (or more) engineers who have written production code within the past two years, in the languages used in the project. Engineers should review credential management practices with the development team to ensure that any keys, passwords, or other sensitive configurations are not checked into source code or in the git history. 
 
 The engineers can be federal government employees or trusted partners from outside the agency from other contracts, or from independent testing contracts. Their names, organizations, comments and approval/disapproval on the overall codebase should be tracked in this document.
@@ -120,15 +114,11 @@ As part of the code review, engineers should reference modern listings of the mo
 
 
 
-
 ### Code Analysis
 
 At least one automated tool for code analysis (such as static code analysis tools) has been run on the codebase to look for security vulnerabilities, and results have been appropriately acted upon. Even if all findings are eventually fixed, if the initial scans revealed significant, severe vulnerabilities (such as SQL injection vulnerabilities), this indicates that the software development team may not be adhering to the best practices required for open source public release.
 
 Automated tooling for code analysis should be incorporated as a regularly scheduled part of the application development process. The development team should briefly document how frequently they commit to running these automated scanning tools, and who will be running the tests, interpreting, and acting upon the results.
-
-
-
 
 #### Toolkit
 
@@ -145,7 +135,6 @@ Below is a list of suggested tools to run for code analysis:
 
 
 
-
 ### Review Licensing
 
 Ensure that acceptable licensing is decided for the project. Most often, software released as open source by the federal government does so under the Creative Commons Zero 1.0
@@ -159,9 +148,10 @@ Suggested licensing:
 
   All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
 
+If your project is not being dedicated to the public domain under CC0, due to being work for hire, or some other documented reason, then choosing another [OSI approved license](https://opensource.org/license) is the next best thing.
+
 #### Results
 *Insert Review Here*
-
 
 
 
@@ -172,8 +162,7 @@ Review the history of commits to the version control system used, and whether th
 If not rebasing, verify that:
 1. There are no obscene or impolite remarks in comments or commit history
 2. There are no sensitive internal URLs/IP Addresses in comments or commit history
-3. There are no credential files such as Passwords, API/SSH/GPG keys checked into
-the repo.
+3. There are no credential files such as Passwords, API/SSH/GPG keys checked into the repo.
 
 Consider using the following tools to perform the tasks above:
 
@@ -187,25 +176,30 @@ Consider using the following tools to perform the tasks above:
 
 
 
-
 ### Review Repository Hygiene
+
 As part of our repository hygiene requirements, the project must include certain files and sections. Using repolinter will help you identify missing files and content that will need to be added to your repository before outbounding.
 
 #### Running repolinter on your repository locally
+
 1. Add [repolinter.json](https://github.com/DSACMS/repo-scaffolder/blob/main/tier2/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json) to the root directory of your project
+
 2. Run command: 
 ```
 repolinter lint
 
 ```
-3. The result produces a list of file and section existence checks, indicating whether
-each requirement was met or not.
+
+3. The result produces a list of file and section existence checks, indicating whether each requirement was met or not.
 
 ![repolinter results](../assets/repolinter-results.png)
 
-#### Running repolinter on your repository via GitHub Actions**
+#### Running repolinter on your repository via GitHub Actions
+
 1. Add the tier-specific [checks.yml](https://github.com/DSACMS/repo-scaffolder/blob/main/tier2/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml) to the .github directory of your project. The file includes a job that runs a repolinter called [repolinter-checks](https://github.com/DSACMS/repo-scaffolder/blob/4d48f831bc21534d599817e98130fa7956e4282b/tier2/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml#L13).
+
 2. Manually trigger the workflow.
+
 3. The result produces an issue on the repository with a list of file and section
 existence checks, indicating whether each requirement was met or not.
 
@@ -213,7 +207,7 @@ existence checks, indicating whether each requirement was met or not.
 
 The project should include the following files and sections [(link to templates)]({{cookiecutter.project_slug}}):
 
-- [ ] README.md
+- [ ] **README.md**
 
     *An essential guide that gives viewers a detailed description of your project*
 
@@ -236,13 +230,13 @@ The project should include the following files and sections [(link to templates)
 | Policies               | This section is to explicitly link to Federal policies and guidelines that are required or recommended for Federal projects to comply with, such as Accessibility (508), Interoperability, Anti-deficiency, Security, Licensing, and other policies that can vary between agencies and domains. |                  |
 | Public Domain          | A best practice is to list the LICENSE under which a project is released at the bottom of the README. In most cases for Federal repos, we default to Creative Commons Zero 1.0 International (world-wide public domain). |                  |
 
-- [ ] LICENSE
+- [ ] **LICENSE**
 
     *License of your project, whether public domain (CC0) or other OSI-approved License. Using
     ‘vanilla’ license text will allow for GitHub to auto-label the license information on the
     repository landing page.*
 
-- [ ] CONTRIBUTING.md
+- [ ] **CONTRIBUTING.md**
 
     *Provides guidance on how users can run your project and make contributions to it*
 
@@ -296,6 +290,7 @@ The project should include the following files and sections [(link to templates)
 
 
 ### Review Project Metadata
+
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**
@@ -316,6 +311,7 @@ Please keep this file up-to-date as you continue development in this repository.
 
 
 ### Review Repository Details
+
 The GitHub repository homepage features a concise description of the project, a list of
 relevant topic tags, and general information about the repository to provide a
 comprehensive overview for users and contributors.
@@ -347,16 +343,14 @@ comprehensive overview for users and contributors.
 
 
 
-
 ### Additional Notes & Questions
 *Insert any notes or questions here*
 
 
 
-
 ### Sign off on risk acceptance of open-sourcing the software product
-After reviewing the materials prepared by the team that is working to open source the product,
-the business owner signs off on a risk acceptance for open-sourcing the software product.
+
+After reviewing the materials prepared by the team that is working to open source the product, the business owner signs off on a risk acceptance for open-sourcing the software product.
 
 Requesting sign off from key people on this request.
 
@@ -369,67 +363,68 @@ Requesting sign off from key people on this request.
 
 
 
-
 ### Flipping the Switch: Making the Repository Public
-Once the repository has passed outbound review, we are ready to “flip the switch” and
-officially make it public. Once made public, there are a couple of actions that need to be
-taken:
+Once the repository has passed outbound review, we are ready to “flip the switch” and officially make it public. Once made public, there are a couple of actions that need to be taken:
 
 #### Repository Actions
 
 Please enable the following features to enhance repository security and maintain code
 quality:
 
-- [ ] Dependabot Alerts
+- [ ] **Dependabot Alerts**
 
     *A GitHub Feature. Get notified when one of your dependencies has a vulnerability*
 
-- [ ] Secret Scanning Alerts
+- [ ] **Secret Scanning Alerts**
 
     *A GitHub Feature. Get notified when a secret is pushed to this repository. Ideally set this up to run after each new commit is pushed to the Repository.*
 
-- [ ] Branch Protections
+- [ ] **Branch Protections**
 
     *Ensures the integrity of important branches by preventing unauthorized actions like force pushes and requiring pull request reviews with specific checks before merging. Dev and main should be protected branches in the repository.*
 
-- [ ] Git Branching
+- [ ] **Git Branching**
 
     *After making the repository public, make sure there is a coherent git branching plan in place. For example: agree to merge feature related pull requests into dev but merge bug fixes into main instead of dev first.*
 
-- [ ] Add Repolinter GH Action to CI
+- [ ] **Add Repolinter GH Action to CI**
 
     *For ongoing adherence to repository hygiene standards, integrate the [repolinter GitHub Action](https://github.com/DSACMS/metrics/blob/main/.github/workflows/checks.yml) into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.*
 
-- [ ] Optional: DCO (Developer Certificate of Origin)
+- [ ] **Optional: DCO (Developer Certificate of Origin)**
 
     *Requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author. The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. The GitHub app to enforce DCO can be found [here](https://github.com/apps/dco) .*
-
 
 #### Communications & Rollout 📣
 
 Share the good news with communities both inside and outside CMS!
 
-- [ ] Draft a launch announcement
+- [ ] **Draft a launch announcement**
+  Be sure to include the following information:
 
-    *Be sure to include the following information:*
- - Repo Description
- - Repo URL
- - Authoring Team Email Contact
- - Authoring Team URL
- - Authorting Team Slack Channel
- - Call to action (file issues, contribute PRs)
-- [ ] Post launch announcement to CMS slack channels
- - #cms-opensource
- - #cms-api-community
- - #cms-data-community
- - #cms-engineering-community
- - #ai-community
-- [ ] Send a launch announcement email
-- [ ] Add launch announcement to a Confluence Wiki Page
+- Repo Description
+  - Repo URL
+  - Authoring Team Email Contact
+  - Authoring Team URL
+  - Authoring Team Slack Channel
+  - Call to action (File issues, contribute PRs)
+
+- [ ] **Post launch announcement to CMS slack channel**
+
+  - #cms-opensource
+  - #cms-api-community
+  - #cms-data-community
+  - #cms-engineering-community
+  - #ai-community
+
+- [ ] **Send a launch announcement email**
+
+- [ ] **Add launch announcement to a Confluence Wiki Page**
 
 #### Tracking 📈
 
 Add your project to our inventories.
 
-- [ ] Add to https://github.com/dsacms/open projects inventory
-- [ ] Add code.json to repository and sent over a pull request to [code.gov](https://code.gov)
+- [ ] **Add to https://github.com/dsacms/open projects inventory**
+
+- [ ] **Add code.json to repository and sent over a pull request to [code.gov](https://code.gov/)**

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -1,4 +1,4 @@
-# DSAC OSPO Outbound Review Checklist
+# CMS OSPO Outbound Review Checklist
 ## Tier 2: Close Collaboration
 ### Instructions
 This is a review process to approve CMS-developed software to be released open source at [github.cms.gov](https://github.cms.gov/).
@@ -24,9 +24,11 @@ If you would like your repository to be released, please complete the following 
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Project Metadata](#review-project-metadata)
+
 [Review Repository Details](#review-repository-details)
 
-[Additional Notes & Questions](#additional-notes--questoins)
+[Additional Notes & Questions](#additional-notes--questions)
 
 [Sign off on risk acceptance of open-sourcing the software product](#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
 
@@ -275,6 +277,9 @@ The project should include the following files and sections [(link to templates)
 
     *Lints repository for missing files and sections above*
 
+- [ ] **code.json**
+
+    *Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)*
 
 
 **Recomended Files:**
@@ -290,6 +295,25 @@ The project should include the following files and sections [(link to templates)
 #### Results
 *Insert Review Here*
 
+
+
+## Review Project Metadata
+As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
+
+**Creating code.json on your repository**
+1. In the `.github` directory, run the command: 
+  ```
+  cookiecutter . –directory=codejson
+  ```
+
+2. Answer various questions about your project.
+
+3. A code.json file will be generated with your responses.
+
+Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
+
+**Results**
+*Insert Review Here*
 
 
 
@@ -326,7 +350,7 @@ comprehensive overview for users and contributors.
 
 
 
-### Additional Notes & Questoins
+### Additional Notes & Questions
 *Insert any notes or questions here*
 
 

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -282,7 +282,7 @@ The project should include the following files and sections [(link to templates)
     *Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)*
 
 
-**Recomended Files:**
+**Recommended Files:**
 - [ ] **CODEOWNERS.md**
 
     *Specifies code ownership and reviewers*
@@ -297,7 +297,7 @@ The project should include the following files and sections [(link to templates)
 
 
 
-## Review Project Metadata
+### Review Project Metadata
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -16,8 +16,6 @@ If you would like your repository to be released, please complete the following 
 
 [Code Analysis](#code-analysis)
 
-[Toolkit](#toolkit)
-
 [Review Licensing](#review-licensing)
 
 [Review Commit History](#review-commit-history)
@@ -132,7 +130,7 @@ Automated tooling for code analysis should be incorporated as a regularly schedu
 
 
 
-### Toolkit
+#### Toolkit
 
 Below is a list of suggested tools to run for code analysis:
 
@@ -312,7 +310,7 @@ As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov
 
 Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
 
-**Results**
+#### Results
 *Insert Review Here*
 
 

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -16,8 +16,6 @@ If you would like your repository to be released, please complete the following 
 
 [Code Analysis](#code-analysis)
 
-[Toolkit](#toolkit)
-
 [Review Licensing](#review-licensing)
 
 [Review Commit History](#review-commit-history)
@@ -159,7 +157,7 @@ running the tests, interpreting, and acting upon the results.
 
 
 
-### Toolkit
+#### Toolkit
 
 Below is a list of suggested tools to run for code analysis:
 
@@ -350,7 +348,7 @@ As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov
 
 Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
 
-**Results**
+#### Results
 *Insert Review Here*
 
 

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -1,6 +1,8 @@
 # CMS OSPO Outbound Review Checklist
 ## Tier 3: Public Repository
+
 ### Instructions
+
 This is a review process to approve CMS-developed software to be released open source.
 If you would like your repository to be released, please complete the following steps.
 
@@ -31,8 +33,6 @@ If you would like your repository to be released, please complete the following 
 [Sign off on risk acceptance of open-sourcing the software product](#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
 
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
-
-
 
 
 
@@ -71,9 +71,6 @@ If you would like your repository to be released, please complete the following 
     Working in the open encourages experimentation and early adoption of cutting-edge
     technologies, leading to faster innovation and improvement in software capabilities.
 
-
-
-
 ### State the Risks of Open Sourcing the Project
 
 - [ ] **Security Risks**
@@ -88,9 +85,6 @@ If you would like your repository to be released, please complete the following 
 - [ ] **Privacy Risks**
 
     Does this project require access to non-public, non-synthetic PII, PHI, or other internal-only CMS systems containing such data or information?
-
-
-
 
 ### Questions
 
@@ -109,8 +103,8 @@ If you answered “yes” to any of the above questions, your project may be ‘
 
 
 
-
 ### Code Review
+
 The existing codebase should be given a one time, top-to-bottom code quality and
 security vulnerability review by two (or more) engineers who have written
 production code within the past two years, in the languages used in the project.
@@ -139,7 +133,6 @@ Security Risks](https://owasp.org/www-project-top-ten/).
 
 
 
-
 ### Code Analysis
 
 At least one automated tool for code analysis (such as static code analysis tools) has been
@@ -153,9 +146,6 @@ Automated tooling for code analysis should be incorporated as a regularly schedu
 of the application development process. The development team should briefly document
 how frequently they commit to running these automated scanning tools, and who will be
 running the tests, interpreting, and acting upon the results.
-
-
-
 
 #### Toolkit
 
@@ -172,24 +162,23 @@ Below is a list of suggested tools to run for code analysis:
 
 
 
-
 ### Review Licensing
 
-Ensure that acceptable licensing is decided for the project. Most often, software released
-as open source by the federal government does so under the Creative Commons Zero 1.0
+Ensure that acceptable licensing is decided for the project. Most often, software released as open source by the federal government does so under the Creative Commons Zero 1.0
 license.
 
 Suggested licensing:
 
  **Public Domain**
 
- - This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
+  This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
 
- - All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+  All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+If your project is not being dedicated to the public domain under CC0, due to being work for hire, or some other documented reason, then choosing another [OSI approved license](https://opensource.org/license) is the next best thing.
 
 #### Results
 *Insert Review Here*
-
 
 
 
@@ -201,8 +190,7 @@ prefers to clean (e.g., rebase) this history before releasing to the public.
 If not rebasing, verify that:
 1. There are no obscene or impolite remarks in comments or commit history
 2. There are no sensitive internal URLs/IP Addresses in comments or commit history
-3. There are no credential files such as Passwords, API/SSH/GPG keys checked into
-the repo.
+3. There are no credential files such as Passwords, API/SSH/GPG keys checked into the repo.
 
 Consider using the following tools to perform the tasks above:
 
@@ -218,34 +206,40 @@ Consider using the following tools to perform the tasks above:
 
 
 ### Review Repository Hygiene
+
 As part of our repository hygiene requirements, the project must include certain files and
 sections. Using repolinter will help you identify missing files and content that will need to
 be added to your repository before outbounding.
 
 #### Running repolinter on your repository locally
+
 1. Add [repolinter.json](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json) to the root directory of your project
+
 2. Run command: 
 ```
 repolinter lint
 
 ```
+
 3. The result produces a list of file and section existence checks, indicating whether
 each requirement was met or not.
 
 ![repolinter results](../assets/repolinter-results.png)
 
-#### Running repolinter on your repository via GitHub Actions**
+#### Running repolinter on your repository via GitHub Actions
+
 1. Add the tier-specific [checks.yml](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml) to the .github directory of your project. The file
 includes a job that runs a repolinter called [repolinter-checks](https://github.com/DSACMS/repo-scaffolder/blob/4d48f831bc21534d599817e98130fa7956e4282b/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml#L13).
+
 2. Manually trigger the workflow.
-3. The result produces an issue on the repository with a list of file and section
-existence checks, indicating whether each requirement was met or not.
+
+3. The result produces an issue on the repository with a list of file and section existence checks, indicating whether each requirement was met or not.
 
 #### Review Content
 
 The project should include the following files and sections [(link to templates)](https://github.com/DSACMS/repo-scaffolder/tree/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D):
 
-- [ ] README.md
+- [ ] **README.md**
 
     *An essential guide that gives viewers a detailed description of your project*
 
@@ -268,13 +262,13 @@ The project should include the following files and sections [(link to templates)
 | Policies               | This section is to explicitly link to Federal policies and guidelines that are required or recommended for Federal projects to comply with, such as Accessibility (508), Interoperability, Anti-deficiency, Security, Licensing, and other policies that can vary between agencies and domains. |                  |
 | Public Domain          | A best practice is to list the LICENSE under which a project is released at the bottom of the README. In most cases for Federal repos, we default to Creative Commons Zero 1.0 International (world-wide public domain). |                  |
 
-- [ ] LICENSE
+- [ ] **LICENSE**
 
     *License of your project, whether public domain (CC0) or other OSI-approved License. Using
     ‘vanilla’ license text will allow for GitHub to auto-label the license information on the
     repository landing page.*
 
-- [ ] CONTRIBUTING.md
+- [ ] **CONTRIBUTING.md**
 
     *Provides guidance on how users can run your project and make contributions to it*
 
@@ -333,7 +327,9 @@ The project should include the following files and sections [(link to templates)
 
 
 
+
 ### Review Project Metadata
+
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**
@@ -354,6 +350,7 @@ Please keep this file up-to-date as you continue development in this repository.
 
 
 ### Review Repository Details
+
 The GitHub repository homepage features a concise description of the project, a list of
 relevant topic tags, and general information about the repository to provide a
 comprehensive overview for users and contributors.
@@ -393,8 +390,7 @@ comprehensive overview for users and contributors.
 
 
 ### Sign off on risk acceptance of open-sourcing the software product
-After reviewing the materials prepared by the team that is working to open source the product,
-the business owner signs off on a risk acceptance for open-sourcing the software product.
+After reviewing the materials prepared by the team that is working to open source the product, the business owner signs off on a risk acceptance for open-sourcing the software product.
 
 Requesting sign off from key people on this request.
 
@@ -407,8 +403,8 @@ Requesting sign off from key people on this request.
 
 
 
-
 ### Flipping the Switch: Making the Repository Public
+
 Once the repository has passed outbound review, we are ready to “flip the switch” and
 officially make it public. Once made public, there are a couple of actions that need to be
 taken:
@@ -418,56 +414,60 @@ taken:
 Please enable the following features to enhance repository security and maintain code
 quality:
 
-- [ ] Dependabot Alerts
+- [ ] **Dependabot Alerts**
 
     *A GitHub Feature. Get notified when one of your dependencies has a vulnerability*
 
-- [ ] Secret Scanning Alerts
+- [ ] **Secret Scanning Alerts**
 
     *A GitHub Feature. Get notified when a secret is pushed to this repository. Ideally set this up to run after each new commit is pushed to the Repository.*
 
-- [ ] Branch Protections
+- [ ] **Branch Protections**
 
     *Ensures the integrity of important branches by preventing unauthorized actions like force pushes and requiring pull request reviews with specific checks before merging. Dev and main should be protected branches in the repository.*
 
-- [ ] Git Branching
+- [ ] **Git Branching**
 
     *After making the repository public, make sure there is a coherent git branching plan in place. For example: agree to merge feature related pull requests into dev but merge bug fixes into main instead of dev first.*
 
-- [ ] Add Repolinter GH Action to CI
+- [ ] **Add Repolinter GH Action to CI**
 
-    *For ongoing adherence to repository hygiene standards, integrate the repolinter GitHub Action into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.*
+    *For ongoing adherence to repository hygiene standards, integrate the [repolinter GitHub Action](https://github.com/DSACMS/metrics/blob/main/.github/workflows/checks.yml) into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.*
 
-- [ ] Optional: DCO (Developer Certificate of Origin)
+- [ ] **Optional: DCO (Developer Certificate of Origin)**
 
     *Requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author. The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. The GitHub app to enforce DCO can be found [here](https://github.com/apps/dco) .*
-
 
 #### Communications & Rollout 📣
 
 Share the good news with communities both inside and outside CMS!
 
-- [ ] Draft a launch announcement
+- [ ] **Draft a launch announcement**
+  Be sure to include the following information:
 
-    *Be sure to include the following information:*
- - Repo Description
- - Repo URL
- - Authoring Team Email Contact
- - Authoring Team URL
- - Authorting Team Slack Channel
- - Call to action (file issues, contribute PRs)
-- [ ] Post launch announcement to CMS slack channels
- - #cms-opensource
- - #cms-api-community
- - #cms-data-community
- - #cms-engineering-community
- - #ai-community
-- [ ] Send a launch announcement email
-- [ ] Add launch announcement to a Confluence Wiki Page
+- Repo Description
+  - Repo URL
+  - Authoring Team Email Contact
+  - Authoring Team URL
+  - Authoring Team Slack Channel
+  - Call to action (File issues, contribute PRs)
+
+- [ ] **Post launch announcement to CMS slack channel**
+
+  - #cms-opensource
+  - #cms-api-community
+  - #cms-data-community
+  - #cms-engineering-community
+  - #ai-community
+
+- [ ] **Send a launch announcement email**
+
+- [ ] **Add launch announcement to a Confluence Wiki Page**
 
 #### Tracking 📈
 
 Add your project to our inventories.
 
-- [ ] Add to https://github.com/dsacms/open projects inventory
-- [ ] Add code.json to repository and sent over a pull request to code.gov
+- [ ] **Add to https://github.com/dsacms/open projects inventory**
+
+- [ ] **Add code.json to repository and sent over a pull request to [code.gov](https://code.gov/)**

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -1,4 +1,4 @@
-# DSAC OSPO Outbound Review Checklist
+# CMS OSPO Outbound Review Checklist
 ## Tier 3: Public Repository
 ### Instructions
 This is a review process to approve CMS-developed software to be released open source.
@@ -24,9 +24,11 @@ If you would like your repository to be released, please complete the following 
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Project Metadata](#review-project-metadata)
+
 [Review Repository Details](#review-repository-details)
 
-[Additional Notes & Questions](#additional-notes--questoins)
+[Additional Notes & Questions](#additional-notes--questions)
 
 [Sign off on risk acceptance of open-sourcing the software product](#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
 
@@ -324,9 +326,32 @@ The project should include the following files and sections [(link to templates)
 
     *Lints repository for missing files and sections above*
 
+- [ ] **code.json**
+
+    *Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)*
+
 #### Results
 *Insert Review Here*
 
+
+
+## Review Project Metadata
+As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
+
+**Creating code.json on your repository**
+1. In the `.github` directory, run the command: 
+  ```
+  cookiecutter . –directory=codejson
+  ```
+
+2. Answer various questions about your project.
+
+3. A code.json file will be generated with your responses.
+
+Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
+
+**Results**
+*Insert Review Here*
 
 
 
@@ -363,7 +388,7 @@ comprehensive overview for users and contributors.
 
 
 
-### Additional Notes & Questoins
+### Additional Notes & Questions
 *Insert any notes or questions here*
 
 

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -335,7 +335,7 @@ The project should include the following files and sections [(link to templates)
 
 
 
-## Review Project Metadata
+### Review Project Metadata
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -88,12 +88,12 @@ If you would like your repository to be released, please complete the following 
 
 ### Questions
 
-- **Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?**
+- Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?
   - Can it be removed? Is it absolutely needed to function? Can it be shipped with synthetic data instead?
 
-- **Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?**
+- Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?
 
-- **Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?**
+- Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?
   - Can it be removed or is it needed?
 
 If you answered “yes” to any of the above questions, your project may be ‘sensitive’ in nature and require a more thorough review before sharing publicly. Please reach out to [opensource@cms.hhs.gov](mailto:opensource@cms.hhs.gov) for guidance. If you answer yes to any of these questions above, it is best to NOT open source the product due to security reasons.

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -336,7 +336,7 @@ The project should include the following files and sections [(link to templates)
 
 
 
-## Review Project Metadata
+### Review Project Metadata
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -1,4 +1,4 @@
-# DSAC OSPO Outbound Review Checklist
+# CMS OSPO Outbound Review Checklist
 ## Tier 4: Community Governance
 ### Instructions
 This is a review process to approve CMS-developed software to be released open source.
@@ -24,11 +24,13 @@ If you would like your repository to be released, please complete the following 
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Project Metadata](#review-project-metadata)
+
 [Review Repository Details](#review-repository-details)
 
 [Review OpenSSF Scorecard](#review-openssf-scorecard)
 
-[Additional Notes & Questions](#additional-notes--questoins)
+[Additional Notes & Questions](#additional-notes--questions)
 
 [Sign off on risk acceptance of open-sourcing the software product](#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
 
@@ -325,9 +327,32 @@ The project should include the following files and sections [(link to templates)
 
     *Lints repository for missing files and sections above*
 
+- [ ] **code.json**
+
+    *Contains metadata about the project, refer to [Review Project Metadata](#review-project-metadata)*
+
 #### Results
 *Insert Review Here*
 
+
+
+## Review Project Metadata
+As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
+
+**Creating code.json on your repository**
+1. In the `.github` directory, run the command: 
+  ```
+  cookiecutter . –directory=codejson
+  ```
+
+2. Answer various questions about your project.
+
+3. A code.json file will be generated with your responses.
+
+Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
+
+**Results**
+*Insert Review Here*
 
 
 
@@ -395,7 +420,7 @@ Overall Score:
 
 
 
-### Additional Notes & Questoins
+### Additional Notes & Questions
 *Insert any notes or questions here*
 
 

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -16,8 +16,6 @@ If you would like your repository to be released, please complete the following 
 
 [Code Analysis](#code-analysis)
 
-[Toolkit](#toolkit)
-
 [Review Licensing](#review-licensing)
 
 [Review Commit History](#review-commit-history)
@@ -160,7 +158,7 @@ running the tests, interpreting, and acting upon the results.
 
 
 
-### Toolkit
+#### Toolkit
 
 Below is a list of suggested tools to run for code analysis:
 
@@ -351,7 +349,7 @@ As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov
 
 Please keep this file up-to-date as you continue development in this repository. The OSPO is currently developing workflows to help assist with this work.
 
-**Results**
+#### Results
 *Insert Review Here*
 
 

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -1,5 +1,6 @@
 # CMS OSPO Outbound Review Checklist
 ## Tier 4: Community Governance
+
 ### Instructions
 This is a review process to approve CMS-developed software to be released open source.
 If you would like your repository to be released, please complete the following steps.
@@ -33,8 +34,6 @@ If you would like your repository to be released, please complete the following 
 [Sign off on risk acceptance of open-sourcing the software product](#sign-off-on-risk-acceptance-of-open-sourcing-the-software-product)
 
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
-
-
 
 
 
@@ -73,9 +72,6 @@ If you would like your repository to be released, please complete the following 
     Working in the open encourages experimentation and early adoption of cutting-edge
     technologies, leading to faster innovation and improvement in software capabilities.
 
-
-
-
 ### State the Risks of Open Sourcing the Project
 
 - [ ] **Security Risks**
@@ -89,9 +85,6 @@ If you would like your repository to be released, please complete the following 
 - [ ] **Privacy Risks**
 
     Does this project require access to non-public, non-synthetic PII, PHI, or other internal-only CMS systems containing such data or information?
-
-
-
 
 ### Questions
 
@@ -112,6 +105,7 @@ If you answered “yes” to any of the above questions, your project may be ‘
 
 
 ### Code Review
+
 The existing codebase should be given a one time, top-to-bottom code quality and
 security vulnerability review by two (or more) engineers who have written
 production code within the past two years, in the languages used in the project.
@@ -155,9 +149,6 @@ of the application development process. The development team should briefly docu
 how frequently they commit to running these automated scanning tools, and who will be
 running the tests, interpreting, and acting upon the results.
 
-
-
-
 #### Toolkit
 
 Below is a list of suggested tools to run for code analysis:
@@ -173,24 +164,23 @@ Below is a list of suggested tools to run for code analysis:
 
 
 
-
 ### Review Licensing
 
-Ensure that acceptable licensing is decided for the project. Most often, software released
-as open source by the federal government does so under the Creative Commons Zero 1.0
+Ensure that acceptable licensing is decided for the project. Most often, software released as open source by the federal government does so under the Creative Commons Zero 1.0
 license.
 
 Suggested licensing:
 
  **Public Domain**
 
- - This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+  This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
 
- - All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+  All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+If your project is not being dedicated to the public domain under CC0, due to being work for hire, or some other documented reason, then choosing another [OSI approved license](https://opensource.org/license) is the next best thing.
 
 #### Results
 *Insert Review Here*
-
 
 
 
@@ -217,36 +207,40 @@ Consider using the following tools to perform the tasks above:
 
 
 
-
 ### Review Repository Hygiene
+
 As part of our repository hygiene requirements, the project must include certain files and
 sections. Using repolinter will help you identify missing files and content that will need to
 be added to your repository before outbounding.
 
 #### Running repolinter on your repository locally
+
 1. Add [repolinter.json](https://github.com/DSACMS/repo-scaffolder/blob/main/tier4/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json) to the root directory of your project
+
 2. Run command: 
 ```
 repolinter lint
 
 ```
-3. The result produces a list of file and section existence checks, indicating whether
-each requirement was met or not.
+
+3. The result produces a list of file and section existence checks, indicating whether each requirement was met or not.
 
 ![repolinter results](../assets/repolinter-results.png)
 
-#### Running repolinter on your repository via GitHub Actions**
+#### Running repolinter on your repository via GitHub Actions
+
 1. Add the tier-specific [checks.yml](https://github.com/DSACMS/repo-scaffolder/blob/main/tier4/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml) to the .github directory of your project. The file
 includes a job that runs a repolinter called [repolinter-checks](https://github.com/DSACMS/repo-scaffolder/blob/4d48f831bc21534d599817e98130fa7956e4282b/tier4/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/checks.yml#L13).
+
 2. Manually trigger the workflow.
-3. The result produces an issue on the repository with a list of file and section
-existence checks, indicating whether each requirement was met or not.
+
+3. The result produces an issue on the repository with a list of file and section existence checks, indicating whether each requirement was met or not.
 
 #### Review Content
 
 The project should include the following files and sections [(link to templates)]({{cookiecutter.project_slug}}):
 
-- [ ] README.md
+- [ ] **README.md**
 
     *An essential guide that gives viewers a detailed description of your project*
 
@@ -269,13 +263,13 @@ The project should include the following files and sections [(link to templates)
 | Policies               | This section is to explicitly link to Federal policies and guidelines that are required or recommended for Federal projects to comply with, such as Accessibility (508), Interoperability, Anti-deficiency, Security, Licensing, and other policies that can vary between agencies and domains. |                  |
 | Public Domain          | A best practice is to list the LICENSE under which a project is released at the bottom of the README. In most cases for Federal repos, we default to Creative Commons Zero 1.0 International (world-wide public domain). |                  |
 
-- [ ] LICENSE
+- [ ] **LICENSE**
 
     *License of your project, whether public domain (CC0) or other OSI-approved License. Using
     ‘vanilla’ license text will allow for GitHub to auto-label the license information on the
     repository landing page.*
 
-- [ ] CONTRIBUTING.md
+- [ ] **CONTRIBUTING.md**
 
     *Provides guidance on how users can run your project and make contributions to it*
 
@@ -334,7 +328,9 @@ The project should include the following files and sections [(link to templates)
 
 
 
+
 ### Review Project Metadata
+
 As part of the [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf) and the agency’s software inventory tracking initiatives, each repository must contain a code.json file, storing metadata on your project.
 
 **Creating code.json on your repository**
@@ -355,6 +351,7 @@ Please keep this file up-to-date as you continue development in this repository.
 
 
 ### Review Repository Details
+
 The GitHub repository homepage features a concise description of the project, a list of
 relevant topic tags, and general information about the repository to provide a
 comprehensive overview for users and contributors.
@@ -386,7 +383,6 @@ comprehensive overview for users and contributors.
 
 
 
-
 ### Review OpenSSF Scorecard 
 | Checks                   | Description & Condition                                                                                          | Risk   | Min | Score |
 |--------------------------|------------------------------------------------------------------------------------------------------------------|--------|-----|-------|
@@ -413,8 +409,7 @@ comprehensive overview for users and contributors.
  
 Overall Score: 
 
- *Insert review here* 
-
+*Insert review here*
 
 
 
@@ -423,10 +418,9 @@ Overall Score:
 
 
 
-
 ### Sign off on risk acceptance of open-sourcing the software product
-After reviewing the materials prepared by the team that is working to open source the product,
-the business owner signs off on a risk acceptance for open-sourcing the software product.
+
+After reviewing the materials prepared by the team that is working to open source the product, the business owner signs off on a risk acceptance for open-sourcing the software product.
 
 Requesting sign off from key people on this request.
 
@@ -441,6 +435,7 @@ Requesting sign off from key people on this request.
 
 
 ### Flipping the Switch: Making the Repository Public
+
 Once the repository has passed outbound review, we are ready to “flip the switch” and
 officially make it public. Once made public, there are a couple of actions that need to be
 taken:
@@ -450,56 +445,60 @@ taken:
 Please enable the following features to enhance repository security and maintain code
 quality:
 
-- [ ] Dependabot Alerts
+- [ ] **Dependabot Alerts**
 
     *A GitHub Feature. Get notified when one of your dependencies has a vulnerability*
 
-- [ ] Secret Scanning Alerts
+- [ ] **Secret Scanning Alerts**
 
     *A GitHub Feature. Get notified when a secret is pushed to this repository. Ideally set this up to run after each new commit is pushed to the Repository.*
 
-- [ ] Branch Protections
+- [ ] **Branch Protections**
 
     *Ensures the integrity of important branches by preventing unauthorized actions like force pushes and requiring pull request reviews with specific checks before merging. Dev and main should be protected branches in the repository.*
 
-- [ ] Git Branching
+- [ ] **Git Branching**
 
     *After making the repository public, make sure there is a coherent git branching plan in place. For example: agree to merge feature related pull requests into dev but merge bug fixes into main instead of dev first.*
 
-- [ ] Add Repolinter GH Action to CI
+- [ ] **Add Repolinter GH Action to CI**
 
     *For ongoing adherence to repository hygiene standards, integrate the [repolinter GitHub Action](https://github.com/DSACMS/metrics/blob/main/.github/workflows/checks.yml) into your CI pipeline. This addition enhances your workflow by automatically enforcing repository cleanliness standards.*
 
-- [ ] Optional: DCO (Developer Certificate of Origin)
+- [ ] **Optional: DCO (Developer Certificate of Origin)**
 
     *Requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author. The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. The GitHub app to enforce DCO can be found [here](https://github.com/apps/dco) .*
-
 
 #### Communications & Rollout 📣
 
 Share the good news with communities both inside and outside CMS!
 
-- [ ] Draft a launch announcement
+- [ ] **Draft a launch announcement**
+  Be sure to include the following information:
 
-    *Be sure to include the following information:*
- - Repo Description
- - Repo URL
- - Authoring Team Email Contact
- - Authoring Team URL
- - Authorting Team Slack Channel
- - Call to action (file issues, contribute PRs)
-- [ ] Post launch announcement to CMS slack channels
- - #cms-opensource
- - #cms-api-community
- - #cms-data-community
- - #cms-engineering-community
- - #ai-community
-- [ ] Send a launch announcement email
-- [ ] Add launch announcement to a Confluence Wiki Page
+- Repo Description
+  - Repo URL
+  - Authoring Team Email Contact
+  - Authoring Team URL
+  - Authoring Team Slack Channel
+  - Call to action (File issues, contribute PRs)
+
+- [ ] **Post launch announcement to CMS slack channel**
+
+  - #cms-opensource
+  - #cms-api-community
+  - #cms-data-community
+  - #cms-engineering-community
+  - #ai-community
+
+- [ ] **Send a launch announcement email**
+
+- [ ] **Add launch announcement to a Confluence Wiki Page**
 
 #### Tracking 📈
 
 Add your project to our inventories.
 
-- [ ] Add to https://github.com/dsacms/open projects inventory
-- [ ] Add code.json to repository and sent over a pull request to code.gov
+- [ ] **Add to https://github.com/dsacms/open projects inventory**
+
+- [ ] **Add code.json to repository and sent over a pull request to [code.gov](https://code.gov/)**

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -88,12 +88,12 @@ If you would like your repository to be released, please complete the following 
 
 ### Questions
 
-- **Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?**
+- Does the code contain or touch any private information such as Personal Identifiable Information (PII) or Protected Health Information (PHI)?
   - Can it be removed? Is it absolutely needed to function? Can it be shipped with synthetic data instead?
 
-- **Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?**
+- Does the code interface with any of CMS’ internal-only systems (e.g. mainframes, JIRA instances, databases, etc…)?
 
-- **Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?**
+- Does the repository contain any keys or credentials to access or authenticate with CMS’ systems?
   - Can it be removed or is it needed?
 
 If you answered “yes” to any of the above questions, your project may be ‘sensitive’ in nature and require a more thorough review before sharing publicly. Please reach out to [opensource@cms.hhs.gov](mailto:opensource@cms.hhs.gov) for guidance. If you answer yes to any of these questions above, it is best to NOT open source the product due to security reasons.


### PR DESCRIPTION
# Docs: Adding new section on Reviewing Project Metadata to all checklists + clean up

## Problem

Now that `code.json` is implemented, we would like to incorporate this into our outbound checklists.

## Solution

Created a new section on Reviewing Project Metadata to all checklists. This includes information on the purpose of `code.json` and instructions on how to create code.json.

PR also includes typo and spacing fixes so all checklists have consistent formatting.