### PR TITLE
Merge Dev into Main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: "run-linting-checks"
+name: "run-checks"
 on:
   push:
     branches:
@@ -52,4 +52,4 @@ jobs:
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.pat }}


### PR DESCRIPTION
## Workflows: Updated token for run-checks repolinter workflow

## Problem
run-checks repolinter workflow is not working due to invalid personal access token

## Solution

Updated personal access token value.