### PR TITLE
Fixed Multi-Select Fields Formatting and Fixed Broken Link

### DIFF
--- a/tier0/{{cookiecutter.project_slug}}/README.md
+++ b/tier0/{{cookiecutter.project_slug}}/README.md
@@ -22,7 +22,7 @@ TODO: Recommended to include since this is an agency-led project -->
 
 ## Author / Team
 
-A full list of contributors can be found on [https://github.cms.gov/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.cms.gov/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors).
+A full list of contributors can be found on [https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors).
 
 <!--
 ## Documentation Index

--- a/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -42,6 +42,13 @@ def prompt_exemption_text(exemptionType):
     print(f"You have selected {exemptionType} for your Usage Type.")
     return input("Please provide a one or two sentence justification for the exemption used: ")
 
+def format_multi_select_fields(text):
+    new_text = text.split(",")
+
+    new_text = [text.strip() for text in new_text]
+
+    return new_text
+
 def update_code_json(json_file_path):
     # Read the JSON 
     with open(json_file_path, 'r') as file:
@@ -50,17 +57,24 @@ def update_code_json(json_file_path):
     # Add date_information and labor hours to the JSON
     data['date'] = get_date_fields()
 
+    # Calculate labor hours
     hours = get_scc_labor_hours()
     if hours:
         data['laborHours'] = hours
     else:
         data['laborHours'] = None
 
+    # Check if usageType is an exemption
     if data['permissions']['usageType'].startswith('exempt'):
         exemption_text = prompt_exemption_text(data['permissions']['usageType'])
         data['permissions']['exemptionText'] = exemption_text
     else:
         del data['permissions']['exemptionText']
+
+    # Format multi-select options
+    data['categories'] = format_multi_select_fields(data['categories'][0])
+    data['languages'] = format_multi_select_fields(data['languages'][0])
+    data['tags'] = format_multi_select_fields(data['tags'][0])
 
     # Update the JSON 
     with open(json_file_path, 'w') as file:

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -18,7 +18,7 @@ TODO: Recommended to include since this is an agency-led project -->
 
 ## Core Team
 
-A full list of contributors can be found on [https://github.cms.gov/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.cms.gov/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors).
+A full list of contributors can be found on [https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors).
 
 <!--
 ## Documentation Index

--- a/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -42,6 +42,13 @@ def prompt_exemption_text(exemptionType):
     print(f"You have selected {exemptionType} for your Usage Type.")
     return input("Please provide a one or two sentence justification for the exemption used: ")
 
+def format_multi_select_fields(text):
+    new_text = text.split(",")
+
+    new_text = [text.strip() for text in new_text]
+
+    return new_text
+
 def update_code_json(json_file_path):
     # Read the JSON 
     with open(json_file_path, 'r') as file:
@@ -50,17 +57,24 @@ def update_code_json(json_file_path):
     # Add date_information and labor hours to the JSON
     data['date'] = get_date_fields()
 
+    # Calculate labor hours
     hours = get_scc_labor_hours()
     if hours:
         data['laborHours'] = hours
     else:
         data['laborHours'] = None
 
+    # Check if usageType is an exemption
     if data['permissions']['usageType'].startswith('exempt'):
         exemption_text = prompt_exemption_text(data['permissions']['usageType'])
         data['permissions']['exemptionText'] = exemption_text
     else:
         del data['permissions']['exemptionText']
+
+    # Format multi-select options
+    data['categories'] = format_multi_select_fields(data['categories'][0])
+    data['languages'] = format_multi_select_fields(data['languages'][0])
+    data['tags'] = format_multi_select_fields(data['tags'][0])
 
     # Update the JSON 
     with open(json_file_path, 'w') as file:

--- a/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -42,6 +42,13 @@ def prompt_exemption_text(exemptionType):
     print(f"You have selected {exemptionType} for your Usage Type.")
     return input("Please provide a one or two sentence justification for the exemption used: ")
 
+def format_multi_select_fields(text):
+    new_text = text.split(",")
+
+    new_text = [text.strip() for text in new_text]
+
+    return new_text
+
 def update_code_json(json_file_path):
     # Read the JSON 
     with open(json_file_path, 'r') as file:
@@ -50,17 +57,24 @@ def update_code_json(json_file_path):
     # Add date_information and labor hours to the JSON
     data['date'] = get_date_fields()
 
+    # Calculate labor hours
     hours = get_scc_labor_hours()
     if hours:
         data['laborHours'] = hours
     else:
         data['laborHours'] = None
 
+    # Check if usageType is an exemption
     if data['permissions']['usageType'].startswith('exempt'):
         exemption_text = prompt_exemption_text(data['permissions']['usageType'])
         data['permissions']['exemptionText'] = exemption_text
     else:
         del data['permissions']['exemptionText']
+
+    # Format multi-select options
+    data['categories'] = format_multi_select_fields(data['categories'][0])
+    data['languages'] = format_multi_select_fields(data['languages'][0])
+    data['tags'] = format_multi_select_fields(data['tags'][0])
 
     # Update the JSON 
     with open(json_file_path, 'w') as file:

--- a/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -37,10 +37,17 @@ def get_scc_labor_hours():
 
         #Otherwise just use previous value as a default value.
         return None
-    
+
 def prompt_exemption_text(exemptionType):
     print(f"You have selected {exemptionType} for your Usage Type.")
     return input("Please provide a one or two sentence justification for the exemption used: ")
+
+def format_multi_select_fields(text):
+    new_text = text.split(",")
+
+    new_text = [text.strip() for text in new_text]
+
+    return new_text
 
 def update_code_json(json_file_path):
     # Read the JSON 
@@ -50,17 +57,24 @@ def update_code_json(json_file_path):
     # Add date_information and labor hours to the JSON
     data['date'] = get_date_fields()
 
+    # Calculate labor hours
     hours = get_scc_labor_hours()
     if hours:
         data['laborHours'] = hours
     else:
         data['laborHours'] = None
 
+    # Check if usageType is an exemption
     if data['permissions']['usageType'].startswith('exempt'):
         exemption_text = prompt_exemption_text(data['permissions']['usageType'])
         data['permissions']['exemptionText'] = exemption_text
     else:
         del data['permissions']['exemptionText']
+
+    # Format multi-select options
+    data['categories'] = format_multi_select_fields(data['categories'][0])
+    data['languages'] = format_multi_select_fields(data['languages'][0])
+    data['tags'] = format_multi_select_fields(data['tags'][0])
 
     # Update the JSON 
     with open(json_file_path, 'w') as file:


### PR DESCRIPTION
## Fixed Multi-Select Fields Formatting and Fixed Broken Link

## Problem

Based on #194, when using cookiecutter to generate code.json, the multi-select fields values are formatted incorrectly.

## Solution

- Added a string formatter in post_gen to format the output properly.
- Corrected link.

## Result

- code.json multi-select fields outputs in the proper format.
- Links are now usable.

## Test Plan

Tested locally.
