### PR TITLE
Cookiecutter: Updated Cookiecutter to use latest release 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cookiecutter==2.4.0
+cookiecutter==2.6.0


### PR DESCRIPTION
## Cookiecutter: Updated Cookiecutter to use latest release 2.6.0

## Problem

Currently, the tool uses cookiecutter 2.4.0, 

## Solution

Updated cookiecutter to 2.6.0 which is the latest version release

## Test Plan
Tested all cookiecutter prompts and works fine!
