### PR TITLE
Docs: Created a README.md for Tier 0 and minor edits

### DIFF
--- a/tier0/README.md
+++ b/tier0/README.md
@@ -1,0 +1,25 @@
+# Tier 0: Private Repository
+
+## What is a Tier 0 Project?
+
+A **Tier 0** project is an **experimental or historical** repository that is **private** and generally used by a single developer or a small group. It typically includes working projects, example scripts, or early prototypes that serve as a foundation for future work or experimentation. This type of project is not shared publicly and often remains private due to its preliminary or incomplete nature.
+
+The main purpose of a Tier 0 project is to provide a space for initial development, exploration, and testing. These repositories generally lack formal documentation or governance structures that are typical of more mature projects.
+
+### Key Characteristics of a Tier 0 Project:
+- **Private** and often limited to individual or small team access.
+- Primarily **experimental or developmental** in nature.
+  
+---
+
+## Files for a Tier 0 Project
+
+Although these projects are private, there are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
+
+| **File**              | **Requirement** | **Description**                                                                                             |
+|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `README.md`           |  Mandatory     | Provides an overview of the project, including its purpose, setup instructions, or any relevant notes for the developer(s). |
+| `LICENSE`             | Mandatory        | Defines the licensing terms under which the project is distributed. |
+| `CONTRIBUTING.md`     | Recommended        | Guidelines for contributing, useful if the project is later opened to collaborators or transitioned to a public repository. |
+
+For more information about sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).

--- a/tier0/{{cookiecutter.project_slug}}/README.md
+++ b/tier0/{{cookiecutter.project_slug}}/README.md
@@ -20,9 +20,9 @@ TODO: Recommended to include since this is an agency-led project -->
 ### Team Mission
 TODO: Recommended to include since this is an agency-led project -->
 
-## Author / Team
+<!-- ## Core Team
 
-A full list of contributors can be found on [https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors).
+A full list of contributors can be found on [https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/graphs/contributors). -->
 
 <!--
 ## Documentation Index
@@ -40,11 +40,11 @@ TODO: Using the "tree -d" command can be a helpful way to generate this informat
 **{list directories and descriptions}**
 -->
 
-## Running Locally
+<!--- 
+## Local Development
 
 ### Installation
-
-<!--- Example Install Instructions
+Example Install Instructions
 
 1. Clone the repo
 


### PR DESCRIPTION
## Docs: Created a README.md for Tier 0 and cleanup

## Problem

We should have a README.md to explain what Tier 0 is. Other tiers have this but not Tier 0 at the moment.

## Solution

- Created a README.md explaining the characteristics and required/recommended files of Tier 0.
- Renamed to Core Team, this is a recommended section so commented it out
- Renamed section to Local Development, this is a recommended section so commented it out