### PR TITLE
Fixed laborHours Calculations

### DIFF
--- a/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,8 +23,10 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            d = json.loads(subprocess.run(["scc","..", "--format","json2"],check=True, capture_output=True).stdout)
-            
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+
+            d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout) 
+                       
             l_hours = d['estimatedScheduleMonths'] * 730.001
 
             return round(l_hours,2)

--- a/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+
+            # Currently only supports specific extensions
+            extensions_to_exclude = [
+                "md"
+            ]
+
+            cmd.extend(extensions_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout) 
                        

--- a/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,14 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-file']
 
-            # Currently only supports specific extensions
-            extensions_to_exclude = [
-                "md"
+            # Currently only supports specific files
+            files_to_exclude = [
+                "checks.yml,README.md,CONTIRBUTING.md,LICENSE,repolinter.json,SECURITY.md"
             ]
 
-            cmd.extend(extensions_to_exclude)
+            cmd.extend(files_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout) 
                        

--- a/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+
+            # Currently only supports specific extensions
+            extensions_to_exclude = [
+                "md"
+            ]
+
+            cmd.extend(extensions_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             

--- a/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,9 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            d = json.loads(subprocess.run(["scc","..", "--format","json2"],check=True, capture_output=True).stdout)
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+
+            d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             
             l_hours = d['estimatedScheduleMonths'] * 730.001
 

--- a/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,14 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-file']
 
-            # Currently only supports specific extensions
-            extensions_to_exclude = [
-                "md"
+            # Currently only supports specific files
+            files_to_exclude = [
+                "checks.yml,auto-changelog.yml,contributors.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md"
             ]
 
-            cmd.extend(extensions_to_exclude)
+            cmd.extend(files_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             

--- a/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,14 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-file']
 
-            # Currently only supports specific extensions
-            extensions_to_exclude = [
-                "md"
+            # Currently only supports specific files
+            files_to_exclude = [
+                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md,GOVERANCE.md"
             ]
 
-            cmd.extend(extensions_to_exclude)
+            cmd.extend(files_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             

--- a/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+
+            # Currently only supports specific extensions
+            extensions_to_exclude = [
+                "md"
+            ]
+
+            cmd.extend(extensions_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             

--- a/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,9 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            d = json.loads(subprocess.run(["scc","..", "--format","json2"],check=True, capture_output=True).stdout)
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+
+            d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
             
             l_hours = d['estimatedScheduleMonths'] * 730.001
 

--- a/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,14 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-file']
 
-            # Currently only supports specific extensions
-            extensions_to_exclude = [
-                "md"
+            # Currently only supports specific files
+            files_to_exclude = [
+                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md,GOVERANCE.md"
             ]
 
-            cmd.extend(extensions_to_exclude)
+            cmd.extend(files_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
                         

--- a/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,7 +23,14 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext']
+
+            # Currently only supports specific extensions
+            extensions_to_exclude = [
+                "md"
+            ]
+
+            cmd.extend(extensions_to_exclude)
 
             d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
                         

--- a/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -23,8 +23,10 @@ def get_scc_labor_hours():
         try:
             #Run scc and load results into a dictionary
             #assuming we are in the .git directory of the repo
-            d = json.loads(subprocess.run(["scc","..", "--format","json2"],check=True, capture_output=True).stdout)
-            
+            cmd = ['scc', '..', '--format', 'json2', '--exclude-ext', "md",]
+
+            d = json.loads(subprocess.run(cmd,check=True, capture_output=True).stdout)
+                        
             l_hours = d['estimatedScheduleMonths'] * 730.001
 
             return round(l_hours,2)


### PR DESCRIPTION
## Fixed laborHours Calculations

## Problem

Overall, labor_hour value is pretty high because it is taking into account the markdown files. We would like to exclude this from the calculation.

## Solution

Included a flag in the scc command that excludes md files.

## Result

A decrease in laborHours

### Before
<img width="183" alt="Screenshot 2024-11-07 at 5 22 28 PM" src="https://github.com/user-attachments/assets/4584aedf-c69b-4515-a031-afd760b80cbd">

### After
<img width="183" alt="Screenshot 2024-11-07 at 5 20 34 PM" src="https://github.com/user-attachments/assets/3b99a489-dee3-4409-83c8-2989d969f17b">

Some important notes regarding the summary line:

* Issue #196 
* We can add more files that we want to exclude to fine tune this

## Test Plan

Tested locally and each tier showed a decrease in labor hours
