### PR TITLE
Repolinter: Updated extendJSON action to include installing dependencies

### DIFF
--- a/.github/extendJSON/action.yml
+++ b/.github/extendJSON/action.yml
@@ -19,6 +19,9 @@ runs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
+    
+    - name: Install dependencies
+      run: pip install pydash
 
     - name: Extend JSON and write to env
       id: resolve-step


### PR DESCRIPTION
## Repolinter: Updated extendJSON action to include installing dependencies

## Problem

Getting an error in most recent job that pydash doesn't exist: https://github.com/DSACMS/repo-scaffolder/actions/runs/11902303164/job/33167039818. I realized I forgot to add a step in the GitHub action to install dependencies.
## Solution

Added a step to install dependencies
