### PR TITLE
Fix ExtendJSON: add shell property

### DIFF
--- a/.github/extendJSON/action.yml
+++ b/.github/extendJSON/action.yml
@@ -21,6 +21,7 @@ runs:
         python-version: '3.9'
     
     - name: Install dependencies
+      shell: bash
       run: pip install pydash
 
     - name: Extend JSON and write to env


### PR DESCRIPTION
## Fix ExtendJSON: add shell property

## Problem

ExtendJSON was failing

## Solution

Specify the required shell.

## Result

Job no longer fails. 

## Test Plan

Test with [nektos/act](https://github.com/nektos/act): 
`doas act -s GITHUB_TOKEN="$(gh auth token)"`
