### PR TITLE
Changed gitleaks and repolinter workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: "run-checks"
+name: "run-linting-checks"
 on:
   push:
     branches:
@@ -14,12 +14,17 @@ jobs:
     name: Tier 3 Checks
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
+      {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
+      {% endraw %}
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+      - uses: DSACMS/repolinter-action@main
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
           # working directory (i.e. under `$GITHUB_WORKSPACE`).
@@ -39,7 +44,7 @@ jobs:
           #   non-intrusive notification.
           #
           # Default: "exit-code"
-          output_type: 'issue'
+          output_type: 'pull-request'
 
           # The title to use for the issue created by repolinter-action. This title
           # should indicate the purpose of the issue, as well as that it was created by
@@ -48,10 +53,10 @@ jobs:
           # This option will be ignored if output_type != "issue".
           #
           # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 3 Repository Hygiene Issue'
-          label_name: 'Tier 3 Remediation'
-          label_color: 'ff69b4'
+          pull_request_labels: 'repolinter, cms-oss, cms-gov'
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.
-          token: ${{ secrets.pat }}
+          {% raw %}
+          token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}
+          {% endraw %}

--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
     name: Tier 1 Checks
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+      - uses: DSACMS/repolinter-action@main
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
           # working directory (i.e. under `$GITHUB_WORKSPACE`).
@@ -41,7 +44,7 @@ jobs:
           #   non-intrusive notification.
           #
           # Default: "exit-code"
-          output_type: 'issue'
+          output_type: 'pull-request'
 
           # The title to use for the issue created by repolinter-action. This title
           # should indicate the purpose of the issue, as well as that it was created by
@@ -50,7 +53,7 @@ jobs:
           # This option will be ignored if output_type != "issue".
           #
           # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 1 Repository Hygiene Issue'
+          pull_request_labels: 'repolinter, cms-oss, cms-gov'
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.

--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -8,11 +8,8 @@ jobs:
     name: Run gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          {% raw %}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+      - uses: actions/checkout@v3
+        with: {fetch-depth: 0}
+
+      - name: Check for GitLeaks
+        uses: gacts/gitleaks@v1

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
     name: Tier 2 Checks
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+      - uses: DSACMS/repolinter-action@main
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
           # working directory (i.e. under `$GITHUB_WORKSPACE`).
@@ -41,7 +44,7 @@ jobs:
           #   non-intrusive notification.
           #
           # Default: "exit-code"
-          output_type: 'issue'
+          output_type: 'pull-request'
 
           # The title to use for the issue created by repolinter-action. This title
           # should indicate the purpose of the issue, as well as that it was created by
@@ -50,7 +53,7 @@ jobs:
           # This option will be ignored if output_type != "issue".
           #
           # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 2 Repository Hygiene Issue'
+          pull_request_labels: 'repolinter, cms-oss, cms-gov'
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -8,11 +8,8 @@ jobs:
     name: Run gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          {% raw %}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+      - uses: actions/checkout@v3
+        with: {fetch-depth: 0}
+
+      - name: Check for GitLeaks
+        uses: gacts/gitleaks@v1

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
     name: Tier 3 Checks
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+      - uses: DSACMS/repolinter-action@main
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
           # working directory (i.e. under `$GITHUB_WORKSPACE`).
@@ -41,7 +44,7 @@ jobs:
           #   non-intrusive notification.
           #
           # Default: "exit-code"
-          output_type: 'issue'
+          output_type: 'pull-request'
 
           # The title to use for the issue created by repolinter-action. This title
           # should indicate the purpose of the issue, as well as that it was created by
@@ -50,7 +53,7 @@ jobs:
           # This option will be ignored if output_type != "issue".
           #
           # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 3 Repository Hygiene Issue'
+          pull_request_labels: 'repolinter, cms-oss, cms-gov'
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -8,11 +8,8 @@ jobs:
     name: Run gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          {% raw %}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+      - uses: actions/checkout@v3
+        with: {fetch-depth: 0}
+
+      - name: Check for GitLeaks
+        uses: gacts/gitleaks@v1

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
     name: Tier 4 Checks
     needs: resolve-repolinter-json
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       {% raw %}
       RAW_JSON: ${{ needs.resolve-repolinter-json.outputs.raw-json }}
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo $RAW_JSON > repolinter.json
-      - uses: newrelic/repolinter-action@v1
+      - uses: DSACMS/repolinter-action@main
         with:
           # A path to the JSON/YAML Repolinter ruleset to use, relative to the workflow
           # working directory (i.e. under `$GITHUB_WORKSPACE`).
@@ -41,7 +44,7 @@ jobs:
           #   non-intrusive notification.
           #
           # Default: "exit-code"
-          output_type: 'issue'
+          output_type: 'pull-request'
 
           # The title to use for the issue created by repolinter-action. This title
           # should indicate the purpose of the issue, as well as that it was created by
@@ -50,7 +53,7 @@ jobs:
           # This option will be ignored if output_type != "issue".
           #
           # Default: "[Repolinter] Open Source Policy Issues"
-          output_name: '[Repolinter] Tier 4 Repository Hygiene Issue'
+          pull_request_labels: 'repolinter, cms-oss, cms-gov'
 
           # The default token is the repolinter token for the DSACMS org
           # You can change it if needed.

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -8,11 +8,8 @@ jobs:
     name: Run gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          {% raw %}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+      - uses: actions/checkout@v3
+        with: {fetch-depth: 0}
+
+      - name: Check for GitLeaks
+        uses: gacts/gitleaks@v1


### PR DESCRIPTION
## Changed gitleaks and repolinter workflows

## Problem
- gitleaks required a license key to work within an org
- repolinter didnt use the new PR action

## Solution

- use a new gitleaks action that doesnt require a license
- change the action that used repolinter

## Result

- gitleaks works
- repolinter check pushes a PR instead of an issue

Some important notes regarding the summary line:

* this needs to get merged in order to solve #223 

## Test Plan

- run actions locally