### PR TITLE
Cookiecutter: Fix .git initalization bug during repo creation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -50,4 +50,119 @@ GitHub Actions
 Total number of contributors: <!--CONTRIBUTOR COUNT START--> <!--CONTRIBUTOR COUNT END-->
 
 <!-- readme: contributors -start -->
+<table>
+	<tbody>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/natalialuzuriaga">
+                    <img src="https://avatars.githubusercontent.com/u/29980737?v=4" width="100;" alt="natalialuzuriaga"/>
+                    <br />
+                    <sub><b>Natalia Luzuriaga</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/IsaacMilarky">
+                    <img src="https://avatars.githubusercontent.com/u/24639268?v=4" width="100;" alt="IsaacMilarky"/>
+                    <br />
+                    <sub><b>Isaac Milarsky</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/aprilselby88">
+                    <img src="https://avatars.githubusercontent.com/u/143460853?v=4" width="100;" alt="aprilselby88"/>
+                    <br />
+                    <sub><b>April</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/vantuyls">
+                    <img src="https://avatars.githubusercontent.com/u/9534576?v=4" width="100;" alt="vantuyls"/>
+                    <br />
+                    <sub><b>Steve Van Tuyl</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/sachin-panayil">
+                    <img src="https://avatars.githubusercontent.com/u/79382140?v=4" width="100;" alt="sachin-panayil"/>
+                    <br />
+                    <sub><b>Sachin Panayil</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/decause-gov">
+                    <img src="https://avatars.githubusercontent.com/u/107957201?v=4" width="100;" alt="decause-gov"/>
+                    <br />
+                    <sub><b>decause-gov</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/Firebird1029">
+                    <img src="https://avatars.githubusercontent.com/u/6111102?v=4" width="100;" alt="Firebird1029"/>
+                    <br />
+                    <sub><b>Brandon Yee</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/JosephGasiorekUSDS">
+                    <img src="https://avatars.githubusercontent.com/u/169079684?v=4" width="100;" alt="JosephGasiorekUSDS"/>
+                    <br />
+                    <sub><b>JosephGasiorekUSDS</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/RicardoZamora01">
+                    <img src="https://avatars.githubusercontent.com/u/41018905?v=4" width="100;" alt="RicardoZamora01"/>
+                    <br />
+                    <sub><b>Ricardo Zamora</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/satwic007">
+                    <img src="https://avatars.githubusercontent.com/u/26257975?v=4" width="100;" alt="satwic007"/>
+                    <br />
+                    <sub><b>satwic007</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/NoobNoob06">
+                    <img src="https://avatars.githubusercontent.com/u/108984067?v=4" width="100;" alt="NoobNoob06"/>
+                    <br />
+                    <sub><b>Keni</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/CreativeNick">
+                    <img src="https://avatars.githubusercontent.com/u/43157506?v=4" width="100;" alt="CreativeNick"/>
+                    <br />
+                    <sub><b>Nick</b></sub>
+                </a>
+            </td>
+		</tr>
+		<tr>
+            <td align="center">
+                <a href="https://github.com/sgarciahelguera">
+                    <img src="https://avatars.githubusercontent.com/u/9489918?v=4" width="100;" alt="sgarciahelguera"/>
+                    <br />
+                    <sub><b>Sebastián</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/jabirG">
+                    <img src="https://avatars.githubusercontent.com/u/109629269?v=4" width="100;" alt="jabirG"/>
+                    <br />
+                    <sub><b>Jabir Ghaffar</b></sub>
+                </a>
+            </td>
+            <td align="center">
+                <a href="https://github.com/DinneK">
+                    <img src="https://avatars.githubusercontent.com/u/63877492?v=4" width="100;" alt="DinneK"/>
+                    <br />
+                    <sub><b>Dinne Kopelevich</b></sub>
+                </a>
+            </td>
+		</tr>
+	<tbody>
+</table>
 <!-- readme: contributors -end -->

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -30,14 +30,21 @@ def addTopic():
     subprocess.call(gh_cli_command)
 
 def moveCookiecutterFile(): 
-    github_dir = os.path.join(os.getcwd(), ".github")
-    os.chdir(github_dir)
+    original_dir = os.getcwd()
 
-    source_path = "cookiecutter.json"
-    destination_dir = "codejson"
-    destination_path = os.path.join(destination_dir, "cookiecutter.json")
+    try:
+        github_dir = os.path.join(original_dir, ".github")
+        os.chdir(github_dir)
 
-    shutil.move(source_path, destination_path)
+        source_path = "cookiecutter.json"
+        destination_dir = "codejson"
+        destination_path = os.path.join(destination_dir, "cookiecutter.json")
+
+        shutil.move(source_path, destination_path)
+    
+    finally:
+        # Moves back to project dir
+        os.chdir(original_dir)
 
 def main():
     moveCookiecutterFile()

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -71,14 +71,21 @@ def addMaintainer():
                 f.write(line)
 
 def moveCookiecutterFile(): 
-    github_dir = os.path.join(os.getcwd(), ".github")
-    os.chdir(github_dir)
+    original_dir = os.getcwd()
 
-    source_path = "cookiecutter.json"
-    destination_dir = "codejson"
-    destination_path = os.path.join(destination_dir, "cookiecutter.json")
+    try:
+        github_dir = os.path.join(original_dir, ".github")
+        os.chdir(github_dir)
 
-    shutil.move(source_path, destination_path)
+        source_path = "cookiecutter.json"
+        destination_dir = "codejson"
+        destination_path = os.path.join(destination_dir, "cookiecutter.json")
+
+        shutil.move(source_path, destination_path)
+    
+    finally:
+        # Moves back to project dir
+        os.chdir(original_dir)
 
 def main():
     if ADD_MAINTAINER == "True":

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -64,16 +64,21 @@ def addMaintainer():
         f.writelines(lines)
 
 def moveCookiecutterFile(): 
-    github_dir = os.path.join(os.getcwd(), ".github")
-    os.chdir(github_dir)
+    original_dir = os.getcwd()
 
-    source_path = "cookiecutter.json"
-    destination_dir = "codejson"
-    destination_path = os.path.join(destination_dir, "cookiecutter.json")
+    try:
+        github_dir = os.path.join(original_dir, ".github")
+        os.chdir(github_dir)
 
-    shutil.move(source_path, destination_path)
+        source_path = "cookiecutter.json"
+        destination_dir = "codejson"
+        destination_path = os.path.join(destination_dir, "cookiecutter.json")
 
-    print("ALL DONEZO")
+        shutil.move(source_path, destination_path)
+    
+    finally:
+        # Moves back to project dir
+        os.chdir(original_dir)
 
 def main():
     if ADD_MAINTAINER == "True":

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -64,14 +64,21 @@ def addMaintainer():
         f.writelines(lines)
 
 def moveCookiecutterFile(): 
-    github_dir = os.path.join(os.getcwd(), ".github")
-    os.chdir(github_dir)
+    original_dir = os.getcwd()
 
-    source_path = "cookiecutter.json"
-    destination_dir = "codejson"
-    destination_path = os.path.join(destination_dir, "cookiecutter.json")
+    try:
+        github_dir = os.path.join(original_dir, ".github")
+        os.chdir(github_dir)
 
-    shutil.move(source_path, destination_path)
+        source_path = "cookiecutter.json"
+        destination_dir = "codejson"
+        destination_path = os.path.join(destination_dir, "cookiecutter.json")
+
+        shutil.move(source_path, destination_path)
+    
+    finally:
+        # Moves back to project dir
+        os.chdir(original_dir)
 
 def main():
     if ADD_MAINTAINER == "True":


### PR DESCRIPTION
## Cookiecutter: Fix .git initalization bug during repo creation

## Problem

While testing prod, I found a bug where .git directory was being created in `.github` instead of the project-level directory.

## Solution

Edited post-gen hook to move location of the working directory back to project level directory before .git initialization occurs.

## Result

- When running `cookiecutter . --directory=tierX`, .git is created in project directory and successfully has initial commit in git log

## Test Plan

Tested locally.
