### PR TITLE
Update CONTRIBUTING.md to include MAINTAINERS.md link

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -157,6 +157,11 @@ authorship metadata will be preserved.
 <!--
 ## Shipping Releases
 
+Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+We adhere to semantic versioning and automatic generation of changelogs
+as described in this file. 
+
+
 TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so?
 -->
 

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -152,11 +152,12 @@ authorship metadata will be preserved.
 
 <!--
 ## Shipping Releases
+
 Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
 We adhere to semantic versioning and automatic generation of changelogs
-as described in this file. 
+as described in this file.
 
-<!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? 
+TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so?
 -->
 
 ## Documentation
@@ -177,7 +178,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -152,6 +152,9 @@ authorship metadata will be preserved.
 
 <!--
 ## Shipping Releases
+Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+We adhere to semantic versioning and automatic generation of changelogs
+as described in this file. 
 
 <!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? 
 -->

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -150,14 +150,13 @@ authorship metadata will be preserved.
 
 -->
 
-
 ## Shipping Releases
 
 Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
 We adhere to semantic versioning and automatic generation of changelogs
-as described in this file. 
-<!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? -->
+as described in this file.
 
+<!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? -->
 
 ## Documentation
 
@@ -177,7 +176,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -153,6 +153,9 @@ authorship metadata will be preserved.
 
 ## Shipping Releases
 
+Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+We adhere to semantic versioning and automatic generation of changelogs
+as described in this file. 
 <!-- TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so? -->
 
 


### PR DESCRIPTION


## Add link to MAINTAINERS.md file in CONTRIBUTING.md

## Problem
There is insufficient guidance on releases in the CONTRIBUTING.md file in tier 4. 

## Solution

Add the link to the relevant file. 

