### PR TITLE
Help Desk: Added GitHub Repository-Level Requests

### DIFF
--- a/docs/.github-directory.md
+++ b/docs/.github-directory.md
@@ -28,7 +28,7 @@ Located in `.github/codejson` are files needed to add metadata to your repositor
 
 ## Help Desk Requests
 
-Located in `.github/ISSUE_TEMPLATES` are issue templates to make requests for repository access and metadata updates. Requests are managed by the repository admins and organization owners. Refer to the [GitHub Manangement Policy](https://dsacms.github.io/ospo-guide/resources/github-management-policy/#github-organization-access-1) for more information.
+Located in `.github/ISSUE_TEMPLATES` are issue templates to make requests for repository access and metadata updates. Requests are managed by the repository admins and organization owners.
 
 | File Name                       | Description                                            |
 | ------------------------------- | ------------------------------------------------------ |

--- a/docs/.github-directory.md
+++ b/docs/.github-directory.md
@@ -25,3 +25,14 @@ Located in `.github/codejson` are files needed to add metadata to your repositor
 | File Name                                                                                                                              | Tier 0 | Tier 1 | Tier 2 | Tier 3 | Tier 4 | Description                                                                                                                                                                                                                                      |
 | :------------------------------------------------------------------------------------------------------------------------------------- | :----- | :----- | :----- | :----- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [CODEOWNERS.md](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/.github/CODEOWNERS.md) |        |        | ✔️     | ✔️     | ✔️     | A file used to define who is responsible for specific parts of the codebase. Learn more in [GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners). |
+
+## Help Desk Requests
+
+Located in `.github/ISSUE_TEMPLATES` are issue templates to make requests for repository access and metadata updates. Requests are managed by the repository admins and organization owners. Refer to the [GitHub Manangement Policy](https://dsacms.github.io/ospo-guide/resources/github-management-policy/#github-organization-access-1) for more information.
+
+| File Name                       | Description                                               |
+| ------------------------------- | --------------------------------------------------------- |
+| add_team_request.md             | Request team to be added to repository                    |
+| outside_collaborator_request.md | Request outside collaborator to be added to repository    |
+| integration_request.md          | Request third-party integration to be added to repository |
+| code_json_request.md            | Request updates to code.json                              |

--- a/docs/.github-directory.md
+++ b/docs/.github-directory.md
@@ -30,9 +30,8 @@ Located in `.github/codejson` are files needed to add metadata to your repositor
 
 Located in `.github/ISSUE_TEMPLATES` are issue templates to make requests for repository access and metadata updates. Requests are managed by the repository admins and organization owners. Refer to the [GitHub Manangement Policy](https://dsacms.github.io/ospo-guide/resources/github-management-policy/#github-organization-access-1) for more information.
 
-| File Name                       | Description                                               |
-| ------------------------------- | --------------------------------------------------------- |
-| add_team_request.md             | Request team to be added to repository                    |
-| outside_collaborator_request.md | Request outside collaborator to be added to repository    |
-| integration_request.md          | Request third-party integration to be added to repository |
-| code_json_request.md            | Request updates to code.json                              |
+| File Name                       | Description                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| add_team_request.md             | Request team to be added to repository                 |
+| outside_collaborator_request.md | Request outside collaborator to be added to repository |
+| code_json_request.md            | Request updates to code.json                           |

--- a/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -1,0 +1,26 @@
+---
+name: Add Team to Repository Request Ticket
+about: Ticket for requesting team to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request a New Team to be Added to a Repository
+
+Please fill out the form below to request a new team to be added to a repository. Note that:
+
+- Maintainer teams have **MAINTAIN** access.
+- Committer teams have **WRITE** access.
+- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
+- **ADMIN** access is restricted to DSACMS organization owners.
+- Upon approval, `COMMUNITY.md` will be updated accordingly.
+
+### Information Required
+
+Team Name: <!-- Provide the team name you'd like to grant access to the repo -->
+Reason for Access: <!-- Provide a 1-2 sentence explanation for access -->
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -8,13 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request a New Team to be Added to a Repository
 
-Please fill out the form below to request a new team to be added to a repository. Note that:
-
-- Maintainer teams have **MAINTAIN** access.
-- Committer teams have **WRITE** access.
-- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
-- **ADMIN** access is restricted to DSACMS organization owners.
-- Upon approval, `COMMUNITY.md` will be updated accordingly.
+Please fill out the form below to request a new team to be added to a repository.
 
 ### Information Required
 

--- a/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -1,0 +1,22 @@
+---
+name: Outside Collaborator Repository Access Request Ticket
+about: Ticket for requesting outside collaborator to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request an outside collaborator to be added to repository
+
+For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+
+### Information Required
+
+Name of individual:
+GitHub username:
+Role in project:
+Role in repository according to COMMUNITY.md (Maintainer, Approver, Reviewer):
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -8,7 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request an outside collaborator to be added to repository
 
-For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+For individuals that are not members of the {{ cookiecutter.project_org }} GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
 
 ### Information Required
 

--- a/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -1,0 +1,26 @@
+---
+name: Add Team to Repository Request Ticket
+about: Ticket for requesting team to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request a New Team to be Added to a Repository
+
+Please fill out the form below to request a new team to be added to a repository. Note that:
+
+- Maintainer teams have **MAINTAIN** access.
+- Committer teams have **WRITE** access.
+- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
+- **ADMIN** access is restricted to DSACMS organization owners.
+- Upon approval, `COMMUNITY.md` will be updated accordingly.
+
+### Information Required
+
+Team Name: <!-- Provide the team name you'd like to grant access to the repo -->
+Reason for Access: <!-- Provide a 1-2 sentence explanation for access -->
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -8,13 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request a New Team to be Added to a Repository
 
-Please fill out the form below to request a new team to be added to a repository. Note that:
-
-- Maintainer teams have **MAINTAIN** access.
-- Committer teams have **WRITE** access.
-- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
-- **ADMIN** access is restricted to DSACMS organization owners.
-- Upon approval, `COMMUNITY.md` will be updated accordingly.
+Please fill out the form below to request a new team to be added to a repository.
 
 ### Information Required
 

--- a/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -1,0 +1,22 @@
+---
+name: Outside Collaborator Repository Access Request Ticket
+about: Ticket for requesting outside collaborator to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request an outside collaborator to be added to repository
+
+For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+
+### Information Required
+
+Name of individual:
+GitHub username:
+Role in project:
+Role in repository according to COMMUNITY.md (Maintainer, Approver, Reviewer):
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -8,7 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request an outside collaborator to be added to repository
 
-For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+For individuals that are not members of the {{ cookiecutter.project_org }} GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
 
 ### Information Required
 

--- a/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -1,0 +1,26 @@
+---
+name: Add Team to Repository Request Ticket
+about: Ticket for requesting team to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request a New Team to be Added to a Repository
+
+Please fill out the form below to request a new team to be added to a repository. Note that:
+
+- Maintainer teams have **MAINTAIN** access.
+- Committer teams have **WRITE** access.
+- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
+- **ADMIN** access is restricted to DSACMS organization owners.
+- Upon approval, `COMMUNITY.md` will be updated accordingly.
+
+### Information Required
+
+Team Name: <!-- Provide the team name you'd like to grant access to the repo -->
+Reason for Access: <!-- Provide a 1-2 sentence explanation for access -->
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/add_team_request.md
@@ -8,13 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request a New Team to be Added to a Repository
 
-Please fill out the form below to request a new team to be added to a repository. Note that:
-
-- Maintainer teams have **MAINTAIN** access.
-- Committer teams have **WRITE** access.
-- If you or other members want to be promoted to **MAINTAIN** access, please indicate this in the form.
-- **ADMIN** access is restricted to DSACMS organization owners.
-- Upon approval, `COMMUNITY.md` will be updated accordingly.
+Please fill out the form below to request a new team to be added to a repository.
 
 ### Information Required
 

--- a/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -1,0 +1,22 @@
+---
+name: Outside Collaborator Repository Access Request Ticket
+about: Ticket for requesting outside collaborator to be added to repository
+title: "[REQUEST]: "
+labels: # TODO: Add labels for categorization of requests
+assignees: # TODO: Add organization owner or help desk team
+---
+
+## Request an outside collaborator to be added to repository
+
+For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+
+### Information Required
+
+Name of individual:
+GitHub username:
+Role in project:
+Role in repository according to COMMUNITY.md (Maintainer, Approver, Reviewer):
+
+### Additional Notes (Optional)
+
+<!-- Provide any additional context or requests -->

--- a/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/outside_collaborator_request.md
@@ -8,7 +8,7 @@ assignees: # TODO: Add organization owner or help desk team
 
 ## Request an outside collaborator to be added to repository
 
-For individuals that are not members of the DSACMS GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
+For individuals that are not members of the {{ cookiecutter.project_org }} GitHub organization, these outside collaborators can request access to a repository. Fill out this issue to file the request or make a pull request to the `COMMUNITY.md` file, then a repository admin will grant access.
 
 ### Information Required
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy contributing!
- Comments should be formatted to a width no greater than 80 columns.
- Files should be exempt of trailing spaces.
- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).
-->

## Help Desk: Added GitHub Repository-Level Requests

## Problem

We would like to add the repo-level help desk issue templates to our repository templates for outbounding as noted in the GitHub Management Policy: https://dsacms.github.io/ospo-guide/resources/github-management-policy/#github-organization-access-1

## Solution

Added new issue templates for the following help desk requests:
- Add team to repo
- Add outside collaborator to repo
We are not including the third party integration request for now.

For each ticket, the labels and assignees field is left empty for the repository admin to update according to the help desk system they have set up.