### PR TITLE
Removed code.json + Syntax Changes

### DIFF
--- a/tier0/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier0/{{cookiecutter.project_slug}}/repolinter.json
@@ -19,17 +19,6 @@
         }
       }
     },
-    "code-json-file-exists": {
-      "level": "error",
-      "rule": {
-        "type": "file-existence",
-        "options": {
-          "globsAny": ["code.json"],
-          "file-name": "code.json",
-          "file-content": ""
-        }
-      }
-    },
     "security-file-exists": {
       "level": "warning",
       "rule": {
@@ -740,10 +729,10 @@
         "type": "file-contents",
         "options": {
           "globsAll": ["{docs/,.github/,}COMMUNITY.md"],
-          "content": "Table of Project Members",
+          "content": "Project Members",
           "flags": "i",
           "file-name": "COMMUNITY.md",
-          "file-content": "## Table of Project Members \n<!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. \n Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer --> \n\n{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.\n\n| Role   | Name    | Affiliation    |\n| :----- | :------ | :------------- |\n| {role} | {names} | {affiliations} |\n"
+          "file-content": "## Project Members \n<!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. \n Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer --> \n\n{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.\n\n| Role   | Name    | Affiliation    |\n| :----- | :------ | :------------- |\n| {role} | {names} | {affiliations} |\n"
         }           
       }
     },


### PR DESCRIPTION
Originally had code.json as a requirement in the repolinter configurations but after testing `repolinter-actions`, its not a good idea. Better to just leave the two workflows (`repolinter-actions` + `automated-codejson-generator`) alone and separate. 

Also, tested on `repolinter-actions` and its running great and building the `COMMUNTIY.md `files and reflecting new changes. However, the current logic doesn't remove old files (`CODEOWNERS.md` + `MAINTANERS.md`) so they're just kind of legacy files. I wonder if this is worth looking into. Thoughts?
