### PR TITLE
Templates: Remove mentions of deleted files + Cookiecutter Updates

### DIFF
--- a/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ def get_scc_labor_hours():
 
             # Currently only supports specific files
             files_to_exclude = [
-                "checks.yml,README.md,CONTIRBUTING.md,LICENSE,repolinter.json,SECURITY.md"
+                "checks.yml,README.md,CONTRIBUTING.md,LICENSE,repolinter.json,SECURITY.md,COMMUNITY.md"
             ]
 
             cmd.extend(files_to_exclude)

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -101,7 +101,7 @@ We also recognize capacity building as a key part of involving a diverse open so
 
 <!--
 ### Community Guidelines
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY.md](COMMUNITY.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 -->
 
 <!--

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -1,23 +1,26 @@
 # {{ cookiecutter.project_name }}
+
 {{ cookiecutter.project_description }}
 
 ## About the Project
-<!-- This should be a longer-form description of the project. It can include history, background, details, problem statements, links to design documents or other supporting materials, or any other information/context that a user or contributor might be interested in. --> 
+
+<!-- This should be a longer-form description of the project. It can include history, background, details, problem statements, links to design documents or other supporting materials, or any other information/context that a user or contributor might be interested in. -->
+
 **{project statement}**
 
-<!-- 
+<!--
 ### Project Mission
-**{project mission}** 
+**{project mission}**
 Provide the core mission and objectives driving this project.-->
 
-<!-- 
+<!--
 ### Agency Mission
-TODO: Recommended to include since this is an agency-led project 
+TODO: Recommended to include since this is an agency-led project
 Provide the mission of the agency and how this project aligns. -->
 
-<!-- 
+<!--
 ### Team Mission
-TODO: Recommended to include since this is an agency-led project 
+TODO: Recommended to include since this is an agency-led project
 Provide the team's mission and how they work together. -->
 
 ## Core Team
@@ -84,7 +87,7 @@ Thank you for considering contributing to an Open Source project of the US Gover
 
 <!--
 ## Codeowners
-The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [CODEOWNERS.md](CODEOWNERS.md).
+The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [COMMUNITY.md](COMMUNITY.md).
 -->
 
 <!--
@@ -121,13 +124,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ### Software Bill of Materials (SBOM)
 
-A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software. 
+A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software.
 
 In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Security](https://www.gsa.gov/technology/it-contract-vehicles-and-purchasing-programs/information-technology-category/it-security/executive-order-14028), a SBOM for this repository is provided here: https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/network/dependencies.
 

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -8,11 +8,11 @@
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
   "receive_updates": [true, false],
-  "add_maintainer": [true, false],
+  "add_team": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-    "add_maintainer": "Would you like to add a maintainer?"
+    "add_team": "Would you like to add project team members?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -58,12 +58,12 @@ def addMaintainer():
         maintainers_table += f"| {maintainer["role"]} | {maintainer["name"]}| {maintainer["github_username"]} | {maintainer["affiliation"]} |\n"
 
     proj_name = "{{ cookiecutter.project_name }}"
-    maintainers_file_path = f"MAINTAINERS.md"
+    community_file_path = f"COMMUNITY.md"
 
-    with open(maintainers_file_path, "r") as f:
+    with open(community_file_path, "r") as f:
         lines = f.readlines()
 
-    with open(maintainers_file_path, "w") as f:
+    with open(community_file_path, "w") as f:
         for line in lines:
             if "| {role} | {names} | {github usernames} | {affiliations}|" in line:
                 f.write(maintainers_table)  # Replace placeholder line with new table of maintainers

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -8,7 +8,7 @@ VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
-ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
+ADD_TEAM = '{{cookiecutter.add_team}}'
 
 def createGithubRepo():
     gh_cli_command = [
@@ -30,34 +30,31 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
-def addMaintainer():
-    maintainers = []
-    add_maintainer = True
-    while add_maintainer:
-        maintainer = {}
-        maintainer["role"] = input("Maintainer's Role (Reviewer, Approver, Maintainer): ").strip()
-        maintainer["name"] = input("Maintainer's Name: ").strip()
-        github_username = input("Maintainer's GitHub Username: ").strip()
-        maintainer["github_username"] = github_username if github_username.startswith('@') else f'@{github_username}'
-        maintainer["affiliation"] = input("Maintainer's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
-        maintainers.append(maintainer)
+def addTeam():
+    team = []
+    add_member = True
+    while add_member:
+        member = {}
+        member["role"] = input("Project Member's Role (Engineer, Project Lead, COR, etc...): ").strip()
+        member["name"] = input("Project Member's Name: ").strip()
+        member["affiliation"] = input("Project Member's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
+        team.append(member)
 
         while True:
-            add_maintainer_input = input("Would you like to add another maintainer? [Y/n]: ").strip().lower()
-            if add_maintainer_input in ("y", "yes", ""):
-                add_maintainer = True
+            add_member_input = input("Would you like to add another project member? [Y/n]: ").strip().lower()
+            if add_member_input in ("y", "yes", ""):
+                add_member = True
                 break
-            elif add_maintainer_input in ("n", "no"):
-                add_maintainer = False
+            elif add_member_input in ("n", "no"):
+                add_member = False
                 break
             else:
                 print("\nInvalid response, please respond with: 'y', 'yes', 'n', 'no', or just press Enter for yes")
 
-    maintainers_table = ""
-    for maintainer in maintainers:
-        maintainers_table += f"| {maintainer["role"]} | {maintainer["name"]}| {maintainer["github_username"]} | {maintainer["affiliation"]} |\n"
+    team_table = ""
+    for member in team:
+        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
 
-    proj_name = "{{ cookiecutter.project_name }}"
     community_file_path = f"COMMUNITY.md"
 
     with open(community_file_path, "r") as f:
@@ -65,8 +62,8 @@ def addMaintainer():
 
     with open(community_file_path, "w") as f:
         for line in lines:
-            if "| {role} | {names} | {github usernames} | {affiliations}|" in line:
-                f.write(maintainers_table)  # Replace placeholder line with new table of maintainers
+            if "| {role} | {names} | {affiliations} |" in line:
+                f.write(team_table)  # Replace placeholder line with new table of project team members
             else:
                 f.write(line)
 
@@ -88,8 +85,8 @@ def moveCookiecutterFile():
         os.chdir(original_dir)
 
 def main():
-    if ADD_MAINTAINER == "True":
-        addMaintainer()
+    if ADD_TEAM == "True":
+        addTeam()
 
     moveCookiecutterFile()
 

--- a/tier2/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
@@ -1,5 +1,7 @@
 # Code Owners
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. List them by GitHub Username-->
+
 {% set code_owners = cookiecutter.code_owners.split(',') %}
 {% for item in code_owners %}- {{ item }}
 {% endfor %}

--- a/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ def get_scc_labor_hours():
 
             # Currently only supports specific files
             files_to_exclude = [
-                "checks.yml,auto-changelog.yml,contributors.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md"
+                "checks.yml,auto-changelog.yml,contributors.yml,code.json,checklist.md,checklist.pdf,README.md,CONTRIBUTING.md,LICENSE,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY.md"
             ]
 
             cmd.extend(files_to_exclude)

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           {% endraw %}
         with:
-          readme_path: MAINTAINERS.md
+          readme_path: COMMUNITY.md
           use_username: false
           commit_message: "update contributors information"
 
@@ -55,17 +55,17 @@ jobs:
             echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
 
 
-      - name: Update MAINTAINERS.md
+      - name: Update COMMUNITY.md
         run: |
           {% raw %}
           CONTRIBUTORS="${{ steps.get_contributors.outputs.contributors }}"
           {% endraw %}
 
-          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' MAINTAINERS.md
+          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
 
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add MAINTAINERS.md
+          git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
 
       - name: Push protected

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -18,10 +18,10 @@ We encourage you to read this project's CONTRIBUTING policy (you are here), its
 
 <!--- TODO: If you have 'good-first-issue' or 'easy' labels for newcomers, mention them here.-->
 
-<!-- 
+<!--
 ### Team Specific Guidelines
 
-TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the MAINTAINERS.md file for further details. 
+TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the COMMUNITY.md file for further details.
 -->
 
 ### Building dependencies
@@ -37,20 +37,20 @@ TODO: This section helps contributors understand any team structure in the proje
 <!--- TODO: Workflow Example
 We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow/)
 
-1.  Fork the project 
-2.  Check out the `main` branch 
+1.  Fork the project
+2.  Check out the `main` branch
 3.  Create a feature branch
-4.  Write code and tests for your change 
+4.  Write code and tests for your change
 5.  From your branch, make a pull request against `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
-6.  Work with repo maintainers to get your change reviewed 
+6.  Work with repo maintainers to get your change reviewed
 7.  Wait for your change to be pulled into `{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/main`
 8.  Delete your feature branch
 -->
 
-<!-- 
+<!--
 ### Testing Conventions
 
-TODO: Discuss where tests can be found, how they are run, and what kind of tests/coverage strategy and goals the project has. 
+TODO: Discuss where tests can be found, how they are run, and what kind of tests/coverage strategy and goals the project has.
 -->
 
 ### Coding Style and Linters
@@ -58,7 +58,7 @@ TODO: Discuss where tests can be found, how they are run, and what kind of tests
 <!--- TODO: HIGHLY ENCOURAGED. Specific tools will vary between different languages/frameworks (e.g. Black for python, eslint for JavaScript, etc...)
 
 1. Mention any style guides you adhere to (e.g. pep8, etc...)
-2. Mention any linters your project uses (e.g. flake8, jslint, etc...) 
+2. Mention any linters your project uses (e.g. flake8, jslint, etc...)
 3. Mention any naming conventions your project uses (e.g. Semantic Versioning, CamelCasing, etc...)
 4. Mention any other content guidelines the project adheres to (e.g. plainlanguage.gov, etc...)
 -->
@@ -87,7 +87,7 @@ When creating an issue please try to adhere to the following format:
     see our .github/ISSUE_TEMPLATE.md for more examples.
 -->
 
-<!--- 
+<!---
 ### Writing Pull Requests
 
 TODO: Pull request example
@@ -119,17 +119,17 @@ columns (You can use `fmt -n -p -w 80` to accomplish this).
 
 Some important notes regarding the summary line:
 
-* Describe what was done; not the result 
-* Use the active voice 
-* Use the present tense 
-* Capitalize properly 
-* Do not end in a period — this is a title/subject 
+* Describe what was done; not the result
+* Use the active voice
+* Use the present tense
+* Capitalize properly
+* Do not end in a period — this is a title/subject
 * Prefix the subject with its scope
 
     see our .github/PULL_REQUEST_TEMPLATE.md for more examples.
 -->
 
-<!--- 
+<!---
 ## Code Review
 
 TODO: Code Review Example
@@ -157,15 +157,15 @@ authorship metadata will be preserved.
 <!--
 ## Shipping Releases
 
-Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+Our general policy for shipping releases can be found in our [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 We adhere to semantic versioning and automatic generation of changelogs
-as described in this file. 
+as described in this file.
 
 
 TODO: What cadence does your project ship new releases? (e.g. one-time, ad-hoc, periodically, upon merge of new patches) Who does so?
 -->
 
-<!--- 
+<!---
 ## Documentation
 
 TODO: Documentation Example
@@ -184,7 +184,7 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 

--- a/tier2/{{cookiecutter.project_slug}}/README.md
+++ b/tier2/{{cookiecutter.project_slug}}/README.md
@@ -1,44 +1,50 @@
 # {{ cookiecutter.project_name }}
+
 {{ cookiecutter.project_description }}
 
 ## About the Project
+
 **{project statement}**
 
 ### Project Vision
+
 **{project vision}**
 
 ### Project Mission
+
 **{project mission}**
 
 ### Agency Mission
+
 <!-- TODO: Must include since this is an agency-led project -->
 
 ### Team Mission
+
 <!-- TODO: Must include since this is an agency-led project -->
 
 ## Core Team
 
-An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAINERS.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
+An up-to-date list of core team members can be found in [COMMUNITY.md](COMMUNITY.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
 
-<!-- 
-## Documentation Index 
+<!--
+## Documentation Index
 
 TODO: This is a like a 'table of contents" for your documentation. Tier 0/1 projects with simple README.md files without many sections may or may not need this, but it is still extremely helpful to provide "bookmark" or "anchor" links to specific sections of your file to be referenced in tickets, docs, or other communication channels.
 
-**{list of .md at top directory and descriptions}** 
+**{list of .md at top directory and descriptions}**
  -->
 
-<!-- 
+<!--
 ## Repository Structure
 
 TODO: Using the "tree -d" command can be a helpful way to generate this information, but, be sure to update it as the project evolves and changes over time.
 
-**{list directories and descriptions}** 
+**{list directories and descriptions}**
 
 -->
 
-<!-- 
-# Development and Software Delivery Lifecycle 
+<!--
+# Development and Software Delivery Lifecycle
 The following guide is for members of the project team who have access to the repository as well as code contributors. The main difference between internal and external contributions is that external contributors will need to fork the project and will not be able to merge their own pull requests. For more information on contributing, see: [CONTRIBUTING.md](./CONTRIBUTING.md).
 -->
 
@@ -77,7 +83,7 @@ Thank you for considering contributing to an Open Source project of the US Gover
 
 ## Codeowners
 
-The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [CODEOWNERS.md](CODEOWNERS.md).
+The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [COMMUNITY.md](COMMUNITY.md).
 
 ## Community
 
@@ -85,11 +91,11 @@ The {{ cookiecutter.project_name }} team is taking a community-first and open so
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 
-We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets. 
+We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets.
 
 ### Community Guidelines
 
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. 
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 
 <!--
 ## Governance
@@ -113,13 +119,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ### Software Bill of Materials (SBOM)
 
-A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software. 
+A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software.
 
 In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Security](https://www.gsa.gov/technology/it-contract-vehicles-and-purchasing-programs/information-technology-category/it-security/executive-order-14028), a SBOM for this repository is provided here: https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/network/dependencies.
 

--- a/tier2/{{cookiecutter.project_slug}}/README.md
+++ b/tier2/{{cookiecutter.project_slug}}/README.md
@@ -95,7 +95,7 @@ We also recognize capacity building as a key part of involving a diverse open so
 
 ### Community Guidelines
 
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY.md](COMMUNITY.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 
 <!--
 ## Governance

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -8,10 +8,12 @@
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
   "receive_updates": [true, false],
+  "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "add_team": "Would you like to add project team members?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -8,6 +8,7 @@ VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+ADD_TEAM = '{{cookiecutter.add_team}}'
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
@@ -43,6 +44,7 @@ def formatUsernames(usernames):
     return "".join(f"- @{username.lstrip('@')}\n" for username in usernames)
 
 def addMaintainer():
+    print("ℹ️ Creating a list of maintainers, approvers, and reviewers")
     maintainers = getUsernames("MAINTAINERS")
     approvers = getUsernames("APPROVERS")
     reviewers = getUsernames("REVIEWERS")
@@ -63,6 +65,44 @@ def addMaintainer():
     with open(community_file_path, "w") as f:
         f.writelines(lines)
 
+def addTeam():
+    print("ℹ️ Creating a table of project team members")
+    team = []
+    add_member = True
+    while add_member:
+        member = {}
+        member["role"] = input("Project Member's Role (Engineer, Project Lead, COR, etc...): ").strip()
+        member["name"] = input("Project Member's Name: ").strip()
+        member["affiliation"] = input("Project Member's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
+        team.append(member)
+
+        while True:
+            add_member_input = input("Would you like to add another project member? [Y/n]: ").strip().lower()
+            if add_member_input in ("y", "yes", ""):
+                add_member = True
+                break
+            elif add_member_input in ("n", "no"):
+                add_member = False
+                break
+            else:
+                print("\nInvalid response, please respond with: 'y', 'yes', 'n', 'no', or just press Enter for yes")
+
+    team_table = ""
+    for member in team:
+        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+
+    community_file_path = f"COMMUNITY.md"
+
+    with open(community_file_path, "r") as f:
+        lines = f.readlines()
+
+    with open(community_file_path, "w") as f:
+        for line in lines:
+            if "| {role} | {names} | {affiliations} |" in line:
+                f.write(team_table)  # Replace placeholder line with new table of project team members
+            else:
+                f.write(line)
+
 def moveCookiecutterFile(): 
     original_dir = os.getcwd()
 
@@ -81,6 +121,9 @@ def moveCookiecutterFile():
         os.chdir(original_dir)
 
 def main():
+    if ADD_TEAM == "True":
+        addTeam()
+
     if ADD_MAINTAINER == "True":
         addMaintainer()
 

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -47,9 +47,9 @@ def addMaintainer():
     approvers = getUsernames("APPROVERS")
     reviewers = getUsernames("REVIEWERS")
 
-    maintainers_file_path = "MAINTAINERS.md"
+    community_file_path = "COMMUNITY.md"
 
-    with open(maintainers_file_path, "r") as f:
+    with open(community_file_path, "r") as f:
         lines = f.readlines()
 
     for i, line in enumerate(lines):
@@ -60,7 +60,7 @@ def addMaintainer():
         elif line.strip() == "## Reviewers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
             lines[i + 1] = formatUsernames(reviewers)
 
-    with open(maintainers_file_path, "w") as f:
+    with open(community_file_path, "w") as f:
         f.writelines(lines)
 
 def moveCookiecutterFile(): 

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -53,12 +53,12 @@ def addMaintainer():
         lines = f.readlines()
 
     for i, line in enumerate(lines):
-        if line.strip() == "## Maintainers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+        if line.strip() == "### Maintainers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
             lines[i + 2] = formatUsernames(maintainers)
-        elif line.strip() == "## Approvers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
-            lines[i + 1] = formatUsernames(approvers)
-        elif line.strip() == "## Reviewers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
-            lines[i + 1] = formatUsernames(reviewers)
+        elif line.strip() == "### Approvers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+            lines[i + 2] = formatUsernames(approvers)
+        elif line.strip() == "### Reviewers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+            lines[i + 2] = formatUsernames(reviewers)
 
     with open(community_file_path, "w") as f:
         f.writelines(lines)

--- a/tier3/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+++ b/tier3/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
@@ -1,5 +1,7 @@
 # Code Owners
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. List them by GitHub Username-->
+
 {% set code_owners = cookiecutter.code_owners.split(',') %}
 {% for item in code_owners %}- {{ item }}
 {% endfor %}

--- a/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ def get_scc_labor_hours():
 
             # Currently only supports specific files
             files_to_exclude = [
-                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md,GOVERANCE.md"
+                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTRIBUTING.md,LICENSE,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY.md,GOVERNANCE.md"
             ]
 
             cmd.extend(files_to_exclude)

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           {% endraw %}
         with:
-          readme_path: MAINTAINERS.md
+          readme_path: COMMUNITY.md
           use_username: false
           commit_message: "update contributors information"
 
@@ -55,17 +55,17 @@ jobs:
             echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
 
 
-      - name: Update MAINTAINERS.md
+      - name: Update COMMUNITY.md
         run: |
           {% raw %}
           CONTRIBUTORS="${{ steps.get_contributors.outputs.contributors }}"
           {% endraw %}
 
-          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' MAINTAINERS.md
+          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
 
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add MAINTAINERS.md
+          git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
 
       - name: Push protected

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,6 +1,7 @@
 # COMMUNITY.md
 
 ## Project Members
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
@@ -24,13 +25,19 @@ The members of {{ cookiecutter.project_repo_name }} community are responsible fo
 
 ### Maintainers:
 
+-
+
 <!-- TODO: List the individuals who are the maintainers. What groups/domains are maintainers a part of? Does your project have domains/areas that are maintained by specific people? List @USERNAMES directly, or any @ALIASES for groups/teams. -->
 
 ### Approvers:
 
+-
+
 <!-- TODO: Who are the project approvers? List out @USERNAMES where possible so they can be tagged in issues/PRs directly. -->
 
 ### Reviewers:
+
+-
 
 <!-- TODO: Who are the project reviewers? List out @USERNAMES where possible so they can be tagged in issues/PRs directly. -->
 

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We encourage you to read this project's CONTRIBUTING policy (you are here), its
 
 ### Team Specific Guidelines
 
-<!-- TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the MAINTAINERS.md file for further details.-->
+<!-- TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the COMMUNITY.md file for further details.-->
 
 ### Building dependencies
 
@@ -125,7 +125,7 @@ Some important notes regarding the summary line:
 
 ## Reviewing Pull Requests
 
-<!--- TODO: Make a brief statement about how pull-requests are reviewed, and who is doing the reviewing. Linking to MAINTAINERS.md can help.
+<!--- TODO: Make a brief statement about how pull-requests are reviewed, and who is doing the reviewing. Linking to COMMUNITY.md can help.
 
 Code Review Example
 
@@ -153,7 +153,7 @@ authorship metadata will be preserved.
 <!--
 ## Shipping Releases
 
-Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+Our general policy for shipping releases can be found in our [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 We adhere to semantic versioning and automatic generation of changelogs
 as described in this file.
 

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -89,7 +89,7 @@ We also recognize capacity building as a key part of involving a diverse open so
 
 ### Community Guidelines
 
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY.md](COMMUNITY.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 
 <!--
 ## Governance

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -1,30 +1,32 @@
 # {{ cookiecutter.project_name }}
+
 {{ cookiecutter.project_description }}
 
 ## About the Project
+
 **{project statement}**
 
-<!--- 
+<!---
 ### Project Vision
 **{project vision}** -->
 
-<!-- 
+<!--
 ### Project Mission
 **{project mission}** -->
 
-<!-- 
+<!--
 ### Agency Mission
 TODO: Good to include since this is an agency-led project -->
 
-<!-- 
+<!--
 ### Team Mission
 TODO: Good to include since this is an agency-led project -->
 
 ## Core Team
 
-An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAINERS.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
+An up-to-date list of core team members can be found in [COMMUNITY.md](COMMUNITY.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
 
-## Documentation Index 
+## Documentation Index
 
 <!-- TODO: This is a like a 'table of contents" for your documentation. Tier 0/1 projects with simple README.md files without many sections may or may not need this, but it is still extremely helpful to provide "bookmark" or "anchor" links to specific sections of your file to be referenced in tickets, docs, or other communication channels.-->
 
@@ -37,7 +39,7 @@ An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAI
 
 **{list directories and descriptions}**
 
-# Development and Software Delivery Lifecycle 
+# Development and Software Delivery Lifecycle
 
 The following guide is for members of the project team who have access to the repository as well as code contributors. The main difference between internal and external contributions is that external contributors will need to fork the project and will not be able to merge their own pull requests. For more information on contributing, see: [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -75,7 +77,7 @@ Thank you for considering contributing to an Open Source project of the US Gover
 
 ## Codeowners
 
-The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [CODEOWNERS.md](CODEOWNERS.md).
+The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [COMMUNITY.md](COMMUNITY.md).
 
 ## Community
 
@@ -83,11 +85,11 @@ The {{ cookiecutter.project_name }} team is taking a community-first and open so
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 
-We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets. 
+We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets.
 
 ### Community Guidelines
 
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. 
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 
 <!--
 ## Governance
@@ -113,13 +115,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ### Software Bill of Materials (SBOM)
 
-A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software. 
+A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software.
 
 In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Security](https://www.gsa.gov/technology/it-contract-vehicles-and-purchasing-programs/information-technology-category/it-security/executive-order-14028), a SBOM for this repository is provided here: https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/network/dependencies.
 

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -8,10 +8,12 @@
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
   "receive_updates": [true, false],
+  "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "add_team": "Would you like to add project team members?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -8,6 +8,7 @@ VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+ADD_TEAM = '{{cookiecutter.add_team}}'
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
@@ -43,6 +44,7 @@ def formatUsernames(usernames):
     return "".join(f"- @{username.lstrip('@')}\n" for username in usernames)
 
 def addMaintainer():
+    print("ℹ️ Creating a list of maintainers, approvers, and reviewers")
     maintainers = getUsernames("MAINTAINERS")
     approvers = getUsernames("APPROVERS")
     reviewers = getUsernames("REVIEWERS")
@@ -63,6 +65,44 @@ def addMaintainer():
     with open(community_file_path, "w") as f:
         f.writelines(lines)
 
+def addTeam():
+    print("ℹ️ Creating a table of project team members")
+    team = []
+    add_member = True
+    while add_member:
+        member = {}
+        member["role"] = input("Project Member's Role (Engineer, Project Lead, COR, etc...): ").strip()
+        member["name"] = input("Project Member's Name: ").strip()
+        member["affiliation"] = input("Project Member's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
+        team.append(member)
+
+        while True:
+            add_member_input = input("Would you like to add another project member? [Y/n]: ").strip().lower()
+            if add_member_input in ("y", "yes", ""):
+                add_member = True
+                break
+            elif add_member_input in ("n", "no"):
+                add_member = False
+                break
+            else:
+                print("\nInvalid response, please respond with: 'y', 'yes', 'n', 'no', or just press Enter for yes")
+
+    team_table = ""
+    for member in team:
+        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+
+    community_file_path = f"COMMUNITY.md"
+
+    with open(community_file_path, "r") as f:
+        lines = f.readlines()
+
+    with open(community_file_path, "w") as f:
+        for line in lines:
+            if "| {role} | {names} | {affiliations} |" in line:
+                f.write(team_table)  # Replace placeholder line with new table of project team members
+            else:
+                f.write(line)
+
 def moveCookiecutterFile(): 
     original_dir = os.getcwd()
 
@@ -81,6 +121,9 @@ def moveCookiecutterFile():
         os.chdir(original_dir)
 
 def main():
+    if ADD_TEAM == "True":
+        addTeam()
+
     if ADD_MAINTAINER == "True":
         addMaintainer()
 

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -47,9 +47,9 @@ def addMaintainer():
     approvers = getUsernames("APPROVERS")
     reviewers = getUsernames("REVIEWERS")
 
-    maintainers_file_path = "MAINTAINERS.md"
+    community_file_path = "COMMUNITY.md"
 
-    with open(maintainers_file_path, "r") as f:
+    with open(community_file_path, "r") as f:
         lines = f.readlines()
 
     for i, line in enumerate(lines):
@@ -60,7 +60,7 @@ def addMaintainer():
         elif line.strip() == "## Reviewers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
             lines[i + 1] = formatUsernames(reviewers)
 
-    with open(maintainers_file_path, "w") as f:
+    with open(community_file_path, "w") as f:
         f.writelines(lines)
 
 def moveCookiecutterFile(): 

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -53,12 +53,12 @@ def addMaintainer():
         lines = f.readlines()
 
     for i, line in enumerate(lines):
-        if line.strip() == "## Maintainers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+        if line.strip() == "### Maintainers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
             lines[i + 2] = formatUsernames(maintainers)
-        elif line.strip() == "## Approvers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
-            lines[i + 1] = formatUsernames(approvers)
-        elif line.strip() == "## Reviewers:" and i + 1 < len(lines) and lines[i + 1].strip() == "-":
-            lines[i + 1] = formatUsernames(reviewers)
+        elif line.strip() == "### Approvers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+            lines[i + 2] = formatUsernames(approvers)
+        elif line.strip() == "### Reviewers:" and i + 2 < len(lines) and lines[i + 2].strip() == "-":
+            lines[i + 2] = formatUsernames(reviewers)
 
     with open(community_file_path, "w") as f:
         f.writelines(lines)

--- a/tier4/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
@@ -1,5 +1,7 @@
 # Code Owners
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. List them by GitHub Username-->
+
 {% set code_owners = cookiecutter.code_owners.split(',') %}
 {% for item in code_owners %}- {{ item }}
 {% endfor %}

--- a/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
+++ b/tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks/post_gen_project.py
@@ -27,7 +27,7 @@ def get_scc_labor_hours():
 
             # Currently only supports specific files
             files_to_exclude = [
-                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTIRBUTING.md,LICENSE,MAINTAINERS.md,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY_GUIDELINES.md,GOVERANCE.md"
+                "checks.yml,auto-changelog.yml,contributors.yml,repoStructure.yml,code.json,checklist.md,checklist.pdf,README.md,CONTRIBUTING.md,LICENSE,repolinter.json,SECURITY.md,CODE_OF_CONDUCT.md,CODEOWNERS.md,COMMUNITY.md,GOVERNANCE.md"
             ]
 
             cmd.extend(files_to_exclude)

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/contributors.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           {% endraw %}
         with:
-          readme_path: MAINTAINERS.md
+          readme_path: COMMUNITY.md
           use_username: false
           commit_message: "update contributors information"
 
@@ -55,17 +55,17 @@ jobs:
             echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
 
 
-      - name: Update MAINTAINERS.md
+      - name: Update COMMUNITY.md
         run: |
           {% raw %}
           CONTRIBUTORS="${{ steps.get_contributors.outputs.contributors }}"
           {% endraw %}
 
-          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' MAINTAINERS.md
+          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
 
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add MAINTAINERS.md
+          git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
 
       - name: Push protected

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,6 +1,7 @@
 # COMMUNITY.md
 
 ## Project Members
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
@@ -24,13 +25,19 @@ The members of {{ cookiecutter.project_repo_name }} community are responsible fo
 
 ### Maintainers:
 
+-
+
 <!-- TODO: List the individuals who are the maintainers. What groups/domains are maintainers a part of? Does your project have domains/areas that are maintained by specific people? List @USERNAMES directly, or any @ALIASES for groups/teams. -->
 
 ### Approvers:
 
+-
+
 <!-- TODO: Who are the project approvers? List out @USERNAMES where possible so they can be tagged in issues/PRs directly. -->
 
 ### Reviewers:
+
+-
 
 <!-- TODO: Who are the project reviewers? List out @USERNAMES where possible so they can be tagged in issues/PRs directly. -->
 

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We encourage you to read this project's CONTRIBUTING policy (you are here), its
 
 ### Team Specific Guidelines
 
-<!-- TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the MAINTAINERS.md file for further details.-->
+<!-- TODO: This section helps contributors understand any team structure in the project (formal or informal.) Encouraged to point towards the COMMUNITY.md file for further details.-->
 
 ### Building dependencies
 
@@ -125,7 +125,7 @@ Some important notes regarding the summary line:
 
 ## Reviewing Pull Requests
 
-<!--- TODO: Make a brief statement about how pull-requests are reviewed, and who is doing the reviewing. Linking to MAINTAINERS.md can help.
+<!--- TODO: Make a brief statement about how pull-requests are reviewed, and who is doing the reviewing. Linking to COMMUNITY.md can help.
 
 Code Review Example
 
@@ -152,7 +152,7 @@ authorship metadata will be preserved.
 
 ## Shipping Releases
 
-Our general policy for shipping releases can be found in our [MAINTAINERS.md](./MAINTAINERS.md) file.
+Our general policy for shipping releases can be found in our [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 We adhere to semantic versioning and automatic generation of changelogs
 as described in this file.
 

--- a/tier4/{{cookiecutter.project_slug}}/README.md
+++ b/tier4/{{cookiecutter.project_slug}}/README.md
@@ -1,22 +1,24 @@
 # {{ cookiecutter.project_name }}
+
 {{ cookiecutter.project_description }}
 
 ## About the Project
+
 **{project_statement}**
 
-<!--- 
+<!---
 ### Project Vision
 **{project vision}** -->
 
-<!-- 
+<!--
 ### Project Mission
 **{project mission}** -->
 
 ## Core Team
 
-An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAINERS.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
+An up-to-date list of core team members can be found in [COMMUNITY.md](COMMUNITY.md). At this time, the project is still building the core team and defining roles and responsibilities. We are eagerly seeking individuals who would like to join the community and help us define and fill these roles.
 
-## Documentation Index 
+## Documentation Index
 
 <!-- TODO: This is a like a 'table of contents" for your documentation. Tier 0/1 projects with simple README.md files without many sections may or may not need this, but it is still extremely helpful to provide "bookmark" or "anchor" links to specific sections of your file to be referenced in tickets, docs, or other communication channels. -->
 
@@ -29,7 +31,7 @@ An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAI
 
 **{list directories and descriptions}**
 
-# Development and Software Delivery Lifecycle 
+# Development and Software Delivery Lifecycle
 
 The following guide is for members of the project team who have access to the repository as well as code contributors. The main difference between internal and external contributions is that external contributors will need to fork the project and will not be able to merge their own pull requests. For more information on contributing, see: [CONTRIBUTING.md](./CONTRIBUTING.md).
 
@@ -66,7 +68,7 @@ Thank you for considering contributing to an Open Source project of the US Gover
 
 ## Codeowners
 
-The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [CODEOWNERS.md](CODEOWNERS.md).
+The contents of this repository are managed by **{responsible organization(s)}**. Those responsible for the code and documentation in this repository can be found in [COMMUNITY.md](COMMUNITY.md).
 
 ## Community
 
@@ -74,13 +76,14 @@ The {{ cookiecutter.project_name }} team is taking a community-first and open so
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 
-We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets. 
+We also recognize capacity building as a key part of involving a diverse open source community. We are doing our best to use accessible language, provide technical and process documents, and offer support to community members with a wide variety of backgrounds and skillsets.
 
 ### Community Guidelines
 
-Principles and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. 
+Principles and guidelines for participating in our open source community are can be found in [COMMUNITY.md](COMMUNITY). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events.
 
 ## Governance
+
 <!-- TODO: Make a short statement about how the project is governed (formally, or informally) and link to the GOVERNANCE.md file.-->
 
 Information about how the {{ cookiecutter.project_name }} community is governed may be found in [GOVERNANCE.md](GOVERNANCE.md).
@@ -103,13 +106,13 @@ questions, just [shoot us an email](mailto:opensource@cms.hhs.gov).
 
 ### Security and Responsible Disclosure Policy
 
-*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+_Submit a vulnerability:_ Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
 
 For more information about our Security, Vulnerability, and Responsible Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ### Software Bill of Materials (SBOM)
 
-A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software. 
+A Software Bill of Materials (SBOM) is a formal record containing the details and supply chain relationships of various components used in building software.
 
 In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Security](https://www.gsa.gov/technology/it-contract-vehicles-and-purchasing-programs/information-technology-category/it-security/executive-order-14028), a SBOM for this repository is provided here: https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/network/dependencies.
 


### PR DESCRIPTION
## Templates: Remove mentions of deleted files + Cookiecutter Updates

## Problem

Continuing work on updating repo-scaffolder to reflect the newest maturity model updates

## Solution

Template edits:
- Remove mentions of MAINTAINERS.md and CODEOWNERS.md
- Minor edits in spacing and styling

COMMUNITY.md Cookiecutter updates:
- Update post_gen_project.py to write to COMMUNITY.md files
- Tiers 2-4 support creation of maintainers, approvers, and reviewers list. Repurposed existing function originally created for Tier 3 & 4 MAINTAINERS.md. 
- New Prompt: Tiers 2-4 support creation of project team table. Repurposed existing function originally created for Tier 2 MAINTAINERS.md

## Result:
Users can now input team member info and create project team table & maintainers list for COMMUNITY.md. Prompt below:
<img width="657" alt="Screenshot 2025-03-31 at 2 44 04 PM" src="https://github.com/user-attachments/assets/6efdc509-83eb-476e-933d-c19ec2477919" />
<img width="494" alt="Screenshot 2025-03-31 at 3 03 06 PM" src="https://github.com/user-attachments/assets/7240a11a-453d-4189-af54-06626a776e16" />
<img width="309" alt="Screenshot 2025-03-31 at 3 03 19 PM" src="https://github.com/user-attachments/assets/52e1b0e2-06a3-47d4-8855-6738fb688d4f" />

## Test Plan
- Created repo templates for all tiers locally using `cookiecutter . --directory=tierX`and successfully created all files. GH actions work as well