### PR TITLE
Added missing repolinter configuration

### DIFF
--- a/tier0/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier0/{{cookiecutter.project_slug}}/repolinter.json
@@ -294,6 +294,19 @@
         }
       }
     },
+    "readme-contains-codeowners": {
+      "level": "off",
+      "rule": {
+        "type": "file-contents",
+        "options": {
+          "globsAll": ["README.md"],
+          "content": "Codeowners",
+          "flags": "i",
+          "file-name": "README.md",
+          "file-content": "## Codeowners \n The contents of this repository are managed by {responsible organization(s)}. Those responsible for the code and documentation in this repository can be found in [COMMUNITY.md](COMMUNITY.md). \n"
+        }
+      }
+    },
     "readme-contains-community": {
       "level": "warning",
       "rule": {

--- a/tier0/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier0/{{cookiecutter.project_slug}}/repolinter.json
@@ -19,17 +19,6 @@
         }
       }
     },
-    "code-json-file-exists": {
-      "level": "error",
-      "rule": {
-        "type": "file-existence",
-        "options": {
-          "globsAny": ["code.json"],
-          "file-name": "code.json",
-          "file-content": ""
-        }
-      }
-    },
     "security-file-exists": {
       "level": "warning",
       "rule": {
@@ -740,10 +729,10 @@
         "type": "file-contents",
         "options": {
           "globsAll": ["{docs/,.github/,}COMMUNITY.md"],
-          "content": "Table of Project Members",
+          "content": "Project Members",
           "flags": "i",
           "file-name": "COMMUNITY.md",
-          "file-content": "## Table of Project Members \n<!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. \n Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer --> \n\n{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.\n\n| Role   | Name    | Affiliation    |\n| :----- | :------ | :------------- |\n| {role} | {names} | {affiliations} |\n"
+          "file-content": "## Project Members \n<!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project. \n Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer --> \n\n{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.\n\n| Role   | Name    | Affiliation    |\n| :----- | :------ | :------------- |\n| {role} | {names} | {affiliations} |\n"
         }           
       }
     },

--- a/tier1/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier1/{{cookiecutter.project_slug}}/repolinter.json
@@ -20,6 +20,9 @@
     "readme-contains-contributing": {
       "level": "warning"
     },
+    "readme-contains-codeowners": {
+      "level": "warning"
+    },
     "readme-contains-project-vision": {
       "level": "off"
     },


### PR DESCRIPTION
## Added missing repolinter configuration

## Problem

When running `repolinter-actions` on tiers 2-4, the following error would appear:

```
Configuration validation failed with error Configuration validation failed with errors: 
configuration.rules['readme-contains-codeowners'] should have required property 'rule'
```

## Solution

The repolinter configuration was missing a section for CODEOWNERS within the readme

## Result

This should now fix this and the repolinter-actions can run normally

## Test Plan

This needs to be merged into main to test but im pretty sure this will fix the bug!
