### PR TITLE
COMMUNITY.md: Updated cookiecutter + moved intro text

### DIFF
--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -11,7 +11,7 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-      "add_team": "Would you like to add project team members?"
+      "add_team": "Would you like to add project team members to COMMUNITY.md?"
     },
     "_copy_without_render": [".github/codejson"]
 }

--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -7,9 +7,11 @@
     "project_visibility": ["public", "internal", "private"],
     "create_repo": [true, false],
     "receive_updates": [true, false],
+    "add_team": [true, false],
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
-      "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
+      "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+      "add_team": "Would you like to add project team members?"
     },
     "_copy_without_render": [".github/codejson"]
 }

--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -8,6 +8,7 @@ VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+ADD_TEAM = '{{cookiecutter.add_team}}'
 
 def createGithubRepo():
     gh_cli_command = [
@@ -29,6 +30,43 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
+def addTeam():
+    team = []
+    add_member = True
+    while add_member:
+        member = {}
+        member["role"] = input("Project Member's Role (Engineer, Project Lead, COR, etc...): ").strip()
+        member["name"] = input("Project Member's Name: ").strip()
+        member["affiliation"] = input("Project Member's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
+        team.append(member)
+
+        while True:
+            add_member_input = input("Would you like to add another project member? [Y/n]: ").strip().lower()
+            if add_member_input in ("y", "yes", ""):
+                add_member = True
+                break
+            elif add_member_input in ("n", "no"):
+                add_member = False
+                break
+            else:
+                print("\nInvalid response, please respond with: 'y', 'yes', 'n', 'no', or just press Enter for yes")
+
+    team_table = ""
+    for member in team:
+        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+
+    community_file_path = f"COMMUNITY.md"
+
+    with open(community_file_path, "r") as f:
+        lines = f.readlines()
+
+    with open(community_file_path, "w") as f:
+        for line in lines:
+            if "| {role} | {names} | {affiliations} |" in line:
+                f.write(team_table)  # Replace placeholder line with new table of project team members
+            else:
+                f.write(line)
+
 def moveCookiecutterFile(): 
     original_dir = os.getcwd()
 
@@ -47,6 +85,9 @@ def moveCookiecutterFile():
         os.chdir(original_dir)
 
 def main():
+    if ADD_TEAM == "True":
+        addTeam()
+        
     moveCookiecutterFile()
     
     subprocess.call(["git", "init", "-b", "main"])

--- a/tier0/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier0/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -3,10 +3,10 @@
 {{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
 
 ## Project Members
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
-
 
 | Role   | Name    | Affiliation    |
 | :----- | :------ | :------------- |

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -11,7 +11,7 @@
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-    "add_team": "Would you like to add project team members?"
+    "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -7,9 +7,11 @@
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
   "receive_updates": [true, false],
+  "add_team": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
-    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?"
+    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "add_team": "Would you like to add project team members?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -8,6 +8,7 @@ VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
 RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+ADD_TEAM = '{{cookiecutter.add_team}}'
 
 def createGithubRepo():
     gh_cli_command = [
@@ -29,6 +30,43 @@ def addTopic():
     ]
     subprocess.call(gh_cli_command)
 
+def addTeam():
+    team = []
+    add_member = True
+    while add_member:
+        member = {}
+        member["role"] = input("Project Member's Role (Engineer, Project Lead, COR, etc...): ").strip()
+        member["name"] = input("Project Member's Name: ").strip()
+        member["affiliation"] = input("Project Member's Affiliation (DSAC, CCSQ, CMMI, etc...): ").strip()
+        team.append(member)
+
+        while True:
+            add_member_input = input("Would you like to add another project member? [Y/n]: ").strip().lower()
+            if add_member_input in ("y", "yes", ""):
+                add_member = True
+                break
+            elif add_member_input in ("n", "no"):
+                add_member = False
+                break
+            else:
+                print("\nInvalid response, please respond with: 'y', 'yes', 'n', 'no', or just press Enter for yes")
+
+    team_table = ""
+    for member in team:
+        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+
+    community_file_path = f"COMMUNITY.md"
+
+    with open(community_file_path, "r") as f:
+        lines = f.readlines()
+
+    with open(community_file_path, "w") as f:
+        for line in lines:
+            if "| {role} | {names} | {affiliations} |" in line:
+                f.write(team_table)  # Replace placeholder line with new table of project team members
+            else:
+                f.write(line)
+
 def moveCookiecutterFile(): 
     original_dir = os.getcwd()
 
@@ -47,6 +85,9 @@ def moveCookiecutterFile():
         os.chdir(original_dir)
 
 def main():
+    if ADD_TEAM == "True":
+        addTeam()
+
     moveCookiecutterFile()
     
     subprocess.call(["git", "init", "-b", "main"])

--- a/tier1/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier1/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,11 +1,12 @@
 # COMMUNITY.md
 
+{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
+
 ## Project Members
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
-
-{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
 
 | Role   | Name    | Affiliation    |
 | :----- | :------ | :------------- |

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -12,7 +12,7 @@
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-    "add_team": "Would you like to add project team members?"
+    "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier2/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier2/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,11 +1,12 @@
 # COMMUNITY.md
 
+{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
+
 ## Project Members
+
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
-
-{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
 
 | Role   | Name    | Affiliation    |
 | :----- | :------ | :------------- |

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -13,8 +13,8 @@
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-    "add_team": "Would you like to add project team members?",
-    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers?"
+    "add_team": "Would you like to add project team members to COMMUNITY.md?",
+    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,12 +1,12 @@
 # COMMUNITY.md
 
+{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
+
 ## Project Members
 
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
-
-{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
 
 | Role   | Name    | Affiliation    |
 | :----- | :------ | :------------- |

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -13,8 +13,8 @@
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
-    "add_team": "Would you like to add project team members?",
-    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers?"
+    "add_team": "Would you like to add project team members to COMMUNITY.md?",
+    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -1,12 +1,12 @@
 # COMMUNITY.md
 
+{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
+
 ## Project Members
 
 <!-- TODO: Who are the points of contact in your project who are responsible/accountable for the project? This can often be an engineering or design manager or leader, who may or may not be the primary maintainers of the project.
 
 Roles to include, but not limited to: Project Owner, Technical Lead, Developers/Contributors, Community Manager, Security Team, Policy Advisor, Contracting Officer's Representative, Compliance Officer, Procurement Officer -->
-
-{{ cookiecutter.project_repo_name }} is supported by a dedicated team of individuals fulfilling various roles to ensure its success, security, and alignment with government standards and agency goals.
 
 | Role   | Name    | Affiliation    |
 | :----- | :------ | :------------- |


### PR DESCRIPTION
## COMMUNITY.md: Updated cookiecutter + moved intro text

## Problem

Iterating on feedback on repo template creation using cookiecutter

## Solution

- Updated `add_team` and `add_maintainer` cookiecutter prompts
- New Prompt: Tiers 0 and 1 now support creation of project team table.