### PR TITLE
Docs: Updated repolinter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ When creating projects, if you want to receive updates then add `dsacms-tierX` a
 
 ### Identify missing files and information using repolinter
 
-<!-- TODO: Revise once repolinter GH actions are up and link to it-->
-
 Repolinter is a tool maintained by the [TODOGroup](https://todogroup.org/) for checking repositories for common open source issues, using pre-defined rulesets. This can be run stand-alone as a script, pre-commit in your IDE, or post-commit or within CI/CD systems!
 
 ✔    =  Pass
@@ -158,14 +156,15 @@ Repolinter is a tool maintained by the [TODOGroup](https://todogroup.org/) for c
 
 ⚠  =  Warn
 
-Tiers of level 1 thru 4 have repolinter.json file in their projects. Tier1 has detailed configuration of all the rules. All the other tiers extends their previous tiers and has only the `rule` and the `level` configuration.
+Tiers of level 0 thru 4 have repolinter.json file in their projects. Tier0 has detailed configuration of all the rules. All the other tiers extends their previous tiers and has only the `rule` and the `level` configuration.
 
 Sample commands to run with the given repolinter.json path:
 
 ```
-repolinter lint .
+repolinter lint . # Runs on target directory
 
-repolinter lint tier4/\{\{cookiecutter.project_slug\}\}
+repolinter lint . --config path/to/repolinter.json # Use if the repolinter config is not in the root dir
+
 ```
 
 #### Automated repolinter actions

--- a/tier0/README.md
+++ b/tier0/README.md
@@ -7,22 +7,37 @@ A **Tier 0** project is an **experimental or historical** repository that is **p
 The main purpose of a Tier 0 project is to provide a space for initial development, exploration, and testing. These repositories generally lack formal documentation or governance structures that are typical of more mature projects.
 
 ### Key Characteristics of a Tier 0 Project:
+
 - **Private** and often limited to individual or small team access.
 - Primarily **experimental or developmental** in nature.
-  
+
 ---
 
 ## Files for a Tier 0 Project
 
 Although these projects are private, there are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
-| **File**              | **Requirement** | **Description**                                                                                             |
-|-----------------------|-----------------|-------------------------------------------------------------------------------------------------------------|
-| `LICENSE`             | Mandatory       | Defines the licensing terms under which the project is distributed. |
-| `code.json`           | Mandatory       | Contains project metadata following government requirements. |
-| `README.md`           | Mandatory       | Provides an overview of the project, including its purpose, setup instructions, or any relevant notes for the developer(s). |
-| `COMMUNITY.md`        | Mandatory       | Lists project team members and points of contact. |
-| `SECURITY.md`         | Recommended     | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code. |
-| `CONTRIBUTING.md`     | Recommended     | Guidelines for contributing, useful if the project is later opened to collaborators or transitioned to a public repository. |
+| **File**          | **Requirement** | **Description**                                                                                                             |
+| ----------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `LICENSE`         | Mandatory       | Defines the licensing terms under which the project is distributed.                                                         |
+| `code.json`       | Mandatory       | Contains project metadata following government requirements.                                                                |
+| `README.md`       | Mandatory       | Provides an overview of the project, including its purpose, setup instructions, or any relevant notes for the developer(s). |
+| `COMMUNITY.md`    | Mandatory       | Lists project team members and points of contact.                                                                           |
+| `SECURITY.md`     | Recommended     | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.            |
+| `CONTRIBUTING.md` | Recommended     | Guidelines for contributing, useful if the project is later opened to collaborators or transitioned to a public repository. |
 
 For more information about sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).
+
+## .github directory
+
+The .github directory includes various files such as GitHub action workflows, code.json metadata cookiecutter creation, and issue templates. For more information, please visit the [.github-directory.md]([../docs/.github-directory.md).
+
+## Repository Hygiene using repolinter
+
+As part of maintaining repository hygiene, repolinter is used to identify missing files and information. `repolinter.json` defines a set of checks that verify the existence of these files in your repository. To run repolinter, execute the following command from the root directory:
+
+```
+repolinter lint .
+```
+
+A GitHub action is also available for running repolinter checks. For more information, please visit [README.md](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter).

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -21,14 +21,24 @@ There are specific files that are required and recommended to include in the rep
 | **File**          | **Requirement** | **Description**                                                                                                                                          |
 | ----------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `LICENSE`         | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                      |
-| `code.json`       | Mandatory       | Contains project metadata following government requirements. |
+| `code.json`       | Mandatory       | Contains project metadata following government requirements.                                                                                             |
 | `README.md`       | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
-| `COMMUNITY.md`    | Mandatory       | Lists project team members and points of contact. |
+| `COMMUNITY.md`    | Mandatory       | Lists project team members and points of contact.                                                                                                        |
 | `SECURITY.md`     | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                         |
 | `CONTRIBUTING.md` | Recommended     | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                           |
 
 For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).
 
-## Workflows
+## .github directory
 
-Located in the `.github` directory are [GitHub Action workflows](../docs/.github-directory.md) that can be used to regularly update your repository.
+The .github directory includes various files such as GitHub action workflows, code.json metadata cookiecutter creation, and issue templates. For more information, please visit the [.github-directory.md]([../docs/.github-directory.md).
+
+## Repository Hygiene using repolinter
+
+As part of maintaining repository hygiene, repolinter is used to identify missing files and information. `repolinter.json` defines a set of checks that verify the existence of these files in your repository. To run repolinter, execute the following command from the root directory:
+
+```
+repolinter lint .
+```
+
+A GitHub action is also available for running repolinter checks. For more information, please visit [README.md](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter).

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -19,18 +19,28 @@ Innersource projects often allow different teams within the same organization to
 
 There are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
-| **File**                  | **Requirement** | **Description**                                                                                                                                          |
-| ------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LICENSE`                 | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                      |
-| `code.json`               | Mandatory       | Contains project metadata following government requirements. |
-| `README.md`               | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
-| `COMMUNITY.md`            | Mandatory       | Lists project team members and points of contact. |
-| `SECURITY.md`             | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                         |
-| `CONTRIBUTING.md`         | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                           |
-| `CODE_OF_CONDUCT.md`      | Mandatory       | Establishes guidelines for professional and respectful behavior to foster a collaborative environment.                                                   |
+| **File**             | **Requirement** | **Description**                                                                                                                                          |
+| -------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LICENSE`            | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                      |
+| `code.json`          | Mandatory       | Contains project metadata following government requirements.                                                                                             |
+| `README.md`          | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers. |
+| `COMMUNITY.md`       | Mandatory       | Lists project team members and points of contact.                                                                                                        |
+| `SECURITY.md`        | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                         |
+| `CONTRIBUTING.md`    | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                           |
+| `CODE_OF_CONDUCT.md` | Mandatory       | Establishes guidelines for professional and respectful behavior to foster a collaborative environment.                                                   |
 
 For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).
 
-## Workflows
+## .github directory
 
-Located in the `.github` directory are [GitHub Action workflows](../docs/.github-directory.md) that can be used to regularly update your repository.
+The .github directory includes various files such as GitHub action workflows, code.json metadata cookiecutter creation, and issue templates. For more information, please visit the [.github-directory.md]([../docs/.github-directory.md).
+
+## Repository Hygiene using repolinter
+
+As part of maintaining repository hygiene, repolinter is used to identify missing files and information. `repolinter.json` defines a set of checks that verify the existence of these files in your repository. To run repolinter, execute the following command from the root directory:
+
+```
+repolinter lint .
+```
+
+A GitHub action is also available for running repolinter checks. For more information, please visit [README.md](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter).

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -18,19 +18,29 @@ A **Tier 3** project is an **open collaboration** effort where the work is condu
 
 There are specific files that are required and recommended to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
-| **File**                  | **Requirement** | **Description**                                                                                                                                                          |
-| ------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `LICENSE`                 | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                                      |
-| `code.json`               | Mandatory       | Contains project metadata following government requirements. |
-| `README.md`               | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers.                 |
-| `COMMUNITY.md`            | Mandatory       | Lists project team members and points of contact with detailed roles and responsibilities. |
-| `SECURITY.md`             | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                                         |
-| `CONTRIBUTING.md`         | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                                           |
-| `CODE_OF_CONDUCT.md`      | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
-| `GOVERNANCE.md`           | Recommended     | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project.  |
+| **File**             | **Requirement** | **Description**                                                                                                                                                          |
+| -------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LICENSE`            | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                                      |
+| `code.json`          | Mandatory       | Contains project metadata following government requirements.                                                                                                             |
+| `README.md`          | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers.                 |
+| `COMMUNITY.md`       | Mandatory       | Lists project team members and points of contact with detailed roles and responsibilities.                                                                               |
+| `SECURITY.md`        | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                                         |
+| `CONTRIBUTING.md`    | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                                           |
+| `CODE_OF_CONDUCT.md` | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
+| `GOVERNANCE.md`      | Recommended     | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project.  |
 
 For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).
 
-## Workflows
+## .github directory
 
-Located in the `.github` directory are [GitHub Action workflows](../docs/.github-directory.md) that can be used to regularly update your repository.
+The .github directory includes various files such as GitHub action workflows, code.json metadata cookiecutter creation, and issue templates. For more information, please visit the [.github-directory.md]([../docs/.github-directory.md).
+
+## Repository Hygiene using repolinter
+
+As part of maintaining repository hygiene, repolinter is used to identify missing files and information. `repolinter.json` defines a set of checks that verify the existence of these files in your repository. To run repolinter, execute the following command from the root directory:
+
+```
+repolinter lint .
+```
+
+A GitHub action is also available for running repolinter checks. For more information, please visit [README.md](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter).

--- a/tier4/README.md
+++ b/tier4/README.md
@@ -16,19 +16,29 @@ A **Tier 4** project is a fully **open and collaborative** project that operates
 
 There are specific files that are required to include in the repository as part of the CMS Open Source Program Office's repository hygiene guidelines and standards.
 
-| **File**                  | **Requirement** | **Description**                                                                                                                                                          |
-| ------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `LICENSE`                 | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                                      |
-| `code.json`               | Mandatory       | Contains project metadata following government requirements. |
-| `README.md`               | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers.                 |
-| `COMMUNITY.md`            | Mandatory       | Lists project team members and points of contact with detailed roles and responsibilities. |
-| `SECURITY.md`             | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                                         |
-| `CONTRIBUTING.md`         | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                                           |
-| `CODE_OF_CONDUCT.md`      | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
-| `GOVERNANCE.md`           | Mandatory       | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project.  |
+| **File**             | **Requirement** | **Description**                                                                                                                                                          |
+| -------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LICENSE`            | Mandatory       | Defines the licensing terms under which the project is distributed.                                                                                                      |
+| `code.json`          | Mandatory       | Contains project metadata following government requirements.                                                                                                             |
+| `README.md`          | Mandatory       | Provides a comprehensive overview of the project, including its purpose, how to install or use it, and any relevant information for users or developers.                 |
+| `COMMUNITY.md`       | Mandatory       | Lists project team members and points of contact with detailed roles and responsibilities.                                                                               |
+| `SECURITY.md`        | Mandatory       | Outlines the agency's security policies, including how to report security issues or vulnerabilities in the code.                                                         |
+| `CONTRIBUTING.md`    | Mandatory       | Offers guidelines for contributing to the project, including code standards, how to submit issues, and creating pull requests.                                           |
+| `CODE_OF_CONDUCT.md` | Mandatory       | Establishes guidelines for acceptable behavior within the community, setting expectations for how contributors should interact in a respectful and collaborative manner. |
+| `GOVERNANCE.md`      | Mandatory       | Describes the governance model of the project, such as decision-making processes and rules for contributing. It ensures a transparent process for managing the project.  |
 
 For more information about required sections and content within the files above, please visit [maturity-model-tiers.md](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md).
 
-## Workflows
+## .github directory
 
-Located in the `.github` directory are [GitHub Action workflows](../docs/.github-directory.md) that can be used to regularly update your repository.
+The .github directory includes various files such as GitHub action workflows, code.json metadata cookiecutter creation, and issue templates. For more information, please visit the [.github-directory.md]([../docs/.github-directory.md).
+
+## Repository Hygiene using repolinter
+
+As part of maintaining repository hygiene, repolinter is used to identify missing files and information. `repolinter.json` defines a set of checks that verify the existence of these files in your repository. To run repolinter, execute the following command from the root directory:
+
+```
+repolinter lint .
+```
+
+A GitHub action is also available for running repolinter checks. For more information, please visit [README.md](https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter).


### PR DESCRIPTION
## Docs: Updated repolinter docs

## Problem

Repolinter docs are outdated.

## Solution

- Updated repolinter description and commands
- Added section on repository hygiene using repolinter to Tier READMEs.
- Edited .github section to point to docs