### PR TITLE
Addresses jinja2.exceptions.TemplateSyntaxError

### DIFF
--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -333,7 +333,7 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
-          token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
 ```
 
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release.

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -329,7 +329,7 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
-          token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
 ```
 
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release.

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -329,7 +329,7 @@ jobs:
       - name: "Auto Generate changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
         with:
-          token: ${{{{ secrets.GITHUB_TOKEN }}}}
+          token: ${{ '{{ secrets.GITHUB_TOKEN }}' }}
 ```
 
 This provided workflow will automatically populate the CHANGELOG.md with all of the associated changes created since the last release that are included in the current release.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy contributing!
- Comments should be formatted to a width no greater than 80 columns.
- Files should be exempt of trailing spaces.
- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).
-->

## Addresses jinja2.exceptions.TemplateSyntaxError

## Problem

Addresses the following observed exception:

  File "CONTRIBUTING.md", line 332, in template
jinja2.exceptions.TemplateSyntaxError: expected token ':', got '}'
  File "CONTRIBUTING.md", line 332
    token: ${{{{ secrets.GITHUB_TOKEN }}}}

## Solution

Proposed syntax change in order for the template to be rendered for the line in 
question  as:

token: ${{ secrets.GITHUB_TOKEN }}

## Result

The proposed template modification resolves the TemplateSyntaxError issue.

## Test Plan

cookiecuter is v2.6.0, jinja2 is v3.1.6

Verified this resolves the issue locally with:

cookiecutter -f ./repo-scaffolder --directory=tier3
