### PR TITLE
Add new risk acceptance language

### DIFF
--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -354,6 +354,32 @@ _Insert any notes or questions here_
 
 ### Sign off on risk acceptance of open-sourcing the software product
 
+- **Date:** Add date
+- **Repository Name:** Add repo-name
+
+Before outbounding this repository, it’s important that the appropriate stakeholders review and acknowledge the risks and responsibilities associated with releasing the code to the public. This step ensures transparency and accountability while enabling informed decision making.
+
+#### Security and Privacy Verification
+- [ ] I acknowledge that this project does **NOT**:
+  - [ ] contain any PII/PHI, or create an identifiable risk to the privacy of an individual.
+  - [ ] interface with any CMS Internal Systems. 
+  - [ ] contain any keys or credentials to authenticate with CMS systems.
+
+#### National Security and Intelligence Verification
+- [ ] I acknowledge that this project is **NOT**:
+  - [ ] primarily for use in national security systems, as defined in Section 11103 of title 40, USC.
+  - [ ] created by an agency or part of an agency that is an element of the intelligence community, as defined in section 3(4) of the National Security Act of 1947.
+  - [ ] exempt under section 552(b) of title 5, USC (commonly known as the "Freedom of Information Act").
+
+#### Export and Regulatory Compliance
+- [ ] I acknowledge that this project is **NOT** prohibited under:
+  - [ ] Export Administration Regulations.
+  - [ ] International Traffic in Arms Regulations (ITAR).
+  - [ ] Regulations of the Transportation Security Administration related to the protection of sensitive information.
+  - [ ] Federal laws and regulations governing the sharing of classified information.
+
+If all boxes have been checked, please proceed to the **Flipping the Switch** section below this one, otherwise, this section must be filled out and approved by the indicated stakeholders before public release.
+
 After reviewing the materials prepared by the team that is working to open source the product, the business owner signs off on a risk acceptance for open-sourcing the software product.
 
 Requesting sign off from key people on this request.


### PR DESCRIPTION
## module-name: Add New Risk Acceptance Language

## Problem
Risk acceptance language in the outbounding checklist was vague allowing for user to skip, if confused.

## Solution
Rework language for clarity.

## Result
New language provides a clear checklist for the user to work through before deciding if they can move ahead in the checklist.

## Note
Currently changes only made for tier 1, after review and merge, changes will be added to tiers 2, 3 and 4.

## Test Plan
Review of language.
