### PR TITLE
addTeam() post gen hook: Fixing f string quotes

### DIFF
--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -53,7 +53,7 @@ def addTeam():
 
     team_table = ""
     for member in team:
-        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+        team_table += f"""| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"""
 
     community_file_path = f"COMMUNITY.md"
 

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -53,7 +53,7 @@ def addTeam():
 
     team_table = ""
     for member in team:
-        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+        team_table += f"""| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"""
 
     community_file_path = f"COMMUNITY.md"
 

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -53,7 +53,7 @@ def addTeam():
 
     team_table = ""
     for member in team:
-        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+        team_table += f"""| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"""
 
     community_file_path = f"COMMUNITY.md"
 

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -89,7 +89,7 @@ def addTeam():
 
     team_table = ""
     for member in team:
-        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+        team_table += f"""| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"""
 
     community_file_path = f"COMMUNITY.md"
 

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -89,7 +89,7 @@ def addTeam():
 
     team_table = ""
     for member in team:
-        team_table += f"| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"
+        team_table += f"""| {member["role"]} | {member["name"]} | {member["affiliation"]} |\n"""
 
     community_file_path = f"COMMUNITY.md"
 


### PR DESCRIPTION
## addTeam() post gen hook: Fixing f string quotes

## Problem

When running the repo scaffolder, I received a syntax error for the team_table f-strings, due to inconsistent quotations.

## Solution

I replaced the f-sring quotes with triple quotes, which resolved the syntax error. 

## Result

The repo scaffolder now runs without error. Note: I suspect this error arose as a result of some funky linting. It would be worth double checking local and repo linting settings.

## Test Plan

For each tier:
1. Create a repo scaffold
2. Ensure that the scaffolding completes without error
3. Double check that nothing else seems amiss
