### PR TITLE
Landing Page: Add how a repo becomes a project section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -463,6 +463,16 @@ img.tree-graphic {
   }
 }
 
+/* Section: Repo to Project */
+.repo-to-project {
+  padding: 80px 0;
+  background-color: var(--white);
+}
+
+#repo-to-project .section-title {
+  margin-bottom: 20px;
+}
+
 /* Section: Repository Templates */
 
 .repository-templates {

--- a/index.html
+++ b/index.html
@@ -565,6 +565,58 @@
       </div>
     </section>
 
+    <!-- How a Repository becomes a Project Section -->
+    <section class="repo-to-project" id="repo-to-project" aria-labelledby="repo-to-project-heading">
+      <div class="container">
+        <div class="section-title">
+          <h2 id="repo-to-project-heading">How a Repository Becomes a Project</h2>
+          <p> A project is more than a repository with a collection of files. A healthy open source project must:</p>
+        </div>
+        <fieldset class="usa-fieldset">
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-goals" type="checkbox">
+            <label class="usa-checkbox__label" for="check-goals">Define a clear goal or purpose</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-maturity-model" type="checkbox">
+            <label class="usa-checkbox__label" for="check-maturity-model">Select and adhere to a maturity model
+              tier</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-structure" type="checkbox">
+            <label class="usa-checkbox__label" for="check-structure">Maintain a clear and organized structure</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-docs" type="checkbox">
+            <label class="usa-checkbox__label" for="check-docs">Provide thorough and up-to-date documentation</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-security" type="checkbox">
+            <label class="usa-checkbox__label" for="check-security">Implement proactive security measures such as checks
+              and vulnerability scanning</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-metadata" type="checkbox">
+            <label class="usa-checkbox__label" for="check-metadata">Publish project metadata</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-development" type="checkbox">
+            <label class="usa-checkbox__label" for="check-development">Foster ongoing development and
+              collaboration</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-contributing" type="checkbox">
+            <label class="usa-checkbox__label" for="check-contributing">Provide instructions on contributing</label>
+          </div>
+          <div class="usa-checkbox">
+            <input class="usa-checkbox__input" id="check-governance" type="checkbox">
+            <label class="usa-checkbox__label" for="check-governance">Establish a governance and decision-making
+              process (if Tier 4)</label>
+          </div>
+        </fieldset>
+      </div>
+    </section>
+
     <!-- CTA Section -->
     <section class="cta" aria-labelledby="cta-heading">
       <div class="container">


### PR DESCRIPTION
## Landing Page: Add how a repo becomes a project section

## Problem

We would like to tie all 3 components of our repo-scaffolder stack together by creating a new section: "How a Repository Becomes a Project"

## Solution

Created new section. For now, it includes a checklist of the components of a health open source project. We will add more content soon!

## Result
<img width="1133" height="520" alt="Screenshot 2025-07-28 at 12 22 58 PM" src="https://github.com/user-attachments/assets/b058d1d7-3b4e-45c0-ae48-7c14868fb064" />

To link directly to section: https://dsacms.github.io/repo-scaffolder/#repo-to-project

## Test Plan

`python3 -m http.server 8000` to run locally and looks great!
