### PR TITLE
Docs: Add repository journey content and repository templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This repository also includes [outbound checklists](#Outbound-Checklists) for ea
 
 For existing repositories, repolinter via GitHub Actions is used to identify any files and information missing from the repository according to their maturity tier.
 
-<!-- TODO: Include more information on outbound checklists -->
-
 <!---
 ### Project Vision
 **{project vision}** -->
@@ -38,9 +36,20 @@ A list of core team members responsible for the code and documentation in this r
 
 ##### Usage
 
-- [Using repo-scaffolder](#Using-repo-scaffolder)
-- [Updating repositories using GitHub Actions](#Updating-projects-with-new-repo-scaffolder-upstream-file-changes)
-- [Documentation](./docs)
+1. [Identify your project's maturity model tier](#1-identify-your-projects-maturity-model-tier)
+2. [Set up your repository](#2-set-up-your-repository)
+  - Create a new repository 
+    - [Using repository templates](#create-a-new-repository-using-repository-templates)
+    - [Using repo-scaffolder](#create-a-new-repository-using-repo-scaffolder)
+  - Add files to an existing repository
+    - [Using repolinter](#add-files-to-an-existing-repository-using-repolinter)
+    - [Using repo-scaffolder](#add-files-to-an-existing-repository-using-repo-scaffolder)
+3. [Review your repository using outbound checklists](#3-review-your-repository-using-outbound-checklists)
+  - [Add metadata to your project](#metadata-collection-using-codejson)
+4. [Maintaining your repository](#4-maintaining-your-repository-using-repo-scaffolder)
+    - [GitHub Actions](#updating-repository-using-github-action-workflows)
+    - [Upstream file changes](#Updating-projects-with-new-repo-scaffolder-upstream-file-changes)
+[Additional Documentation](./docs)
 
 ##### Maturity Models
 
@@ -70,45 +79,7 @@ A list of core team members responsible for the code and documentation in this r
 
 ## Using repo-scaffolder
 
-### Create a new repository using repository templates
-
-Use our GitHub repository templates to create a repository of any tier:
-- [Tier 0](https://github.com/DSACMS/tier0)
-- [Tier 1](https://github.com/DSACMS/tier1)
-- [Tier 2](https://github.com/DSACMS/tier2)
-- [Tier 3](https://github.com/DSACMS/tier3)
-- [Tier 4](https://github.com/DSACMS/tier4)
-
-
-### Create a new repository using cookiecutter
-
-The Open Source Program Office follows a maturity model framework to classify federal repositories according to their level of maturity: https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md.
-
-There are 4 tiers in the maturity model framework. The `/tier*` directory consists of templates, files, and scripts for each respective tier:
-
-- `{{cookiecutter.project_slug}}` is the directory containing templates and files to be generated upon repository creation. This serves as your repository starting point.
-- `cookiecutter.json` defining the questions cookiecutter asks.
-- `hooks`, a folder containing scripts to be run upon repository creation.
-- `checklist.md` & `checklist.pdf` is the outbound review checklist with guidelines on releasing the repository as open source.
-- `README.md` with more information about the maturity tier and file contents.
-
-#### Prerequisites
-
-- python
-- github cli
-- [cookiecutter](https://github.com/cookiecutter/cookiecutter)
-- [repolinter](https://github.com/todogroup/repolinter)
-
-##### Installation (On Mac)
-
-```
-python3 -m venv venv
-. venv/bin/activate
-pip install -r requirements.txt
-brew install gh
-```
-
-#### Need help picking a maturity tier?
+### 1. Identify your project's maturity model tier
 
 If you do not know what tier your project is, the `tier-determiner.py` script will walk you through questions to figure out what tier you need. Run:
 
@@ -119,49 +90,52 @@ python tier-determiner.py
 You can also follow the flowchart below to determine your project's tier.
 ![Tier Selection Flowchart](./assets/images/flowchart.png)
 
-#### Know what maturity tier you need?
+### 2. Set up your repository
 
-If you know what tier you need, you can run the cookiecutter for an individual tier. Use the below command with `X` substituted for the tier number.
+#### Create a new repository using repository templates
+
+Use our GitHub repository templates to create a repository of any tier:
+- [Tier 0](https://github.com/DSACMS/tier0)
+- [Tier 1](https://github.com/DSACMS/tier1)
+- [Tier 2](https://github.com/DSACMS/tier2)
+- [Tier 3](https://github.com/DSACMS/tier3)
+- [Tier 4](https://github.com/DSACMS/tier4)
+
+#### Create a new repository using repo-scaffolder
+
+The `/tier*` directory consists of templates, files, and scripts for each respective tier:
+
+- `{{cookiecutter.project_slug}}` is the directory containing templates and files to be generated upon repository creation. This serves as your repository starting point.
+- `cookiecutter.json` defining the questions cookiecutter asks.
+- `hooks`, a folder containing scripts to be run upon repository creation.
+- `checklist.md` & `checklist.pdf` is the outbound review checklist with guidelines on releasing the repository as open source.
+- `README.md` with more information about the maturity tier and file contents.
+
+**Now that you identified your project's maturity model tier, use the command below to create a new repository, with `X` substituted for the tier number.**
 
 ```
 cookiecutter https://github.com/DSACMS/repo-scaffolder --directory=tierX
 ```
 
-### Update an existing repository using repo-scaffolder
+##### Prerequisites
 
-You can update existing projects with repo-scaffolder. Using the `-s` flag on cookiecutter will not overwrite existing files. Follow these steps:
+- python
+- github cli
+- [cookiecutter](https://github.com/cookiecutter/cookiecutter)
+- [repolinter](https://github.com/todogroup/repolinter)
 
-1. Create a new branch in your repo
-2. cd into folder above
-3. run: `cookiecutter -f -s https://github.com/DSACMS/repo-scaffolder --directory=tierX`
-4. Make sure when answering the questions you use the existing folder/project name
-5. Raise pr into main
-
-### Metadata collection using code.json
-
-<!-- TODO: Add text here about code.json and link code.json docs -->
-
-#### Add code.json to your project
-
-Each repository should contain a code.json file with metadata about the project.
-
-To add code.json into your project, navigate to your project's `.github` directory and run the following cookiecutter command. You will be asked questions about the project (see cookiecutter.json) in order to collect and store this metadata in code.json.
+###### Installation (On Mac)
 
 ```
-cookiecutter . --directory=codejson
+python3 -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt
+brew install gh
 ```
 
-### Maintaining your repository using repo-scaffolder
+#### Add files to an existing repository using repolinter
 
-#### Updating repository using GitHub action workflows
-
-The OSPO created various [GitHub Action workflows](../docs/workflows.md) that can be used to regularly update your repository. The jobs are located in `.github` directory of your project.
-
-#### Updating projects with new repo-scaffolder upstream file changes
-
-When creating projects, if you want to receive updates then add `dsacms-tierX` as a github topic to the repo. The scaffolder repo includes github workflows that will find all repos with that tag and can raise a pull request with an updated string or adding a file. See [actions.md](https://github.com/DSACMS/repo-scaffolder/blob/main/.github/actions.md) for more information.
-
-### Identify missing files and information using repolinter
+##### Identify missing files and information using repolinter
 
 Repolinter is a tool maintained by the [TODOGroup](https://todogroup.org/) for checking repositories for common open source issues, using pre-defined rulesets. This can be run stand-alone as a script, pre-commit in your IDE, or post-commit or within CI/CD systems!
 
@@ -182,9 +156,46 @@ repolinter lint . --config path/to/repolinter.json # Use if the repolinter confi
 
 ```
 
-#### Automated repolinter actions
+##### Use automated repolinter GitHub Actions to add files
 
-A tool to automatically update repositories up to hygenic standards with the use of [Repolinter through GitHub Actions](https://github.com/DSACMS/repolinter-actions) is also available. This action sends a PR to your repository with templates of all the missing files and sections that are required using a predefined rulset. Visit the repository for more information on how to get this action up and running.
+A tool to automatically update repositories up to hygienic standards with the use of [Repolinter through GitHub Actions](https://github.com/DSACMS/repolinter-actions) is also available. This action sends a PR to your repository with templates of all the missing files and sections that are required using a predefined ruleset. Visit the repository for more information on how to get this action up and running.
+
+#### Add files to an existing repository using repo-scaffolder
+
+For repositories that have already exist and are in active development, you can update and add required files using repo-scaffolder. Using the `-s` flag on cookiecutter will not overwrite existing files. Follow these steps:
+
+1. Create a new branch in your repo
+2. cd into folder above
+3. run: `cookiecutter -f -s https://github.com/DSACMS/repo-scaffolder --directory=tierX`
+4. Make sure when answering the questions you use the existing folder/project name
+5. Raise pr into main
+
+### 3. Review your repository using Outbound Checklists
+Before releasing your project as open source, follow the [outbound checklists](#outbound-checklists) to review your repository.
+
+#### Metadata collection using code.json
+
+code.json is a metadata standard used to collect information on agency software projects. Every repository is required to have a code.json file.
+
+Learn more about code.json: https://github.com/DSACMS/gov-codejson
+
+#### Add code.json to your project
+
+To add code.json into your project, navigate to your project's `.github` directory and run the following cookiecutter command. You will be asked questions about the project (see cookiecutter.json) in order to collect and store this metadata in code.json.
+
+```
+cookiecutter . --directory=codejson
+```
+
+### 4. Maintaining your repository using repo-scaffolder
+
+#### Updating repository using GitHub Action workflows
+
+The OSPO created various [GitHub Action workflows](../docs/workflows.md) that can be used to regularly update your repository. The jobs are located in `.github` directory of your project.
+
+#### Updating projects with new repo-scaffolder upstream file changes
+
+When creating projects, if you want to receive updates then add `dsacms-tierX` as a github topic to the repo. The scaffolder repo includes github workflows that will find all repos with that tag and can raise a pull request with an updated string or adding a file. See [actions.md](https://github.com/DSACMS/repo-scaffolder/blob/main/.github/actions.md) for more information.
 
 #### Automated Releases and Guidelines
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ A list of core team members responsible for the code and documentation in this r
 
 1. [Identify your project's maturity model tier](#1-identify-your-projects-maturity-model-tier)
 2. [Set up your repository](#2-set-up-your-repository)
-  - Create a new repository 
-    - [Using repository templates](#create-a-new-repository-using-repository-templates)
-    - [Using repo-scaffolder](#create-a-new-repository-using-repo-scaffolder)
-  - Add files to an existing repository
-    - [Using repolinter](#add-files-to-an-existing-repository-using-repolinter)
-    - [Using repo-scaffolder](#add-files-to-an-existing-repository-using-repo-scaffolder)
+    - Create a new repository 
+      - [Using repository templates](#create-a-new-repository-using-repository-templates)
+      - [Using repo-scaffolder](#create-a-new-repository-using-repo-scaffolder)
+    - Add files to an existing repository
+      - [Using repolinter](#add-files-to-an-existing-repository-using-repolinter)
+      - [Using repo-scaffolder](#add-files-to-an-existing-repository-using-repo-scaffolder)
 3. [Review your repository using outbound checklists](#3-review-your-repository-using-outbound-checklists)
-  - [Add metadata to your project](#metadata-collection-using-codejson)
+    - [Add metadata to your project](#metadata-collection-using-codejson)
 4. [Maintaining your repository](#4-maintaining-your-repository-using-repo-scaffolder)
     - [GitHub Actions](#updating-repository-using-github-action-workflows)
     - [Upstream file changes](#Updating-projects-with-new-repo-scaffolder-upstream-file-changes)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Templates and commandline tools for creating repositories for US Federal open so
 
 The CMS Open Source Program Office developed a [maturity model framework](https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md) to classify federal open source projects based on their maturity level. Each tier outlines specific files and content that are required or recommended to be included in the repository.
 
-The repo-scaffolder project creates repositories that adhere to open source hygiene standards and best practices. It provides templates and guidance for project metadata, contributing practices, community governance, feedback mechanisms, security policies, and more. Using [cookiecutter](https://github.com/cookiecutter/cookiecutter), repo-scaffolder helps teams identify what tier their project is classified as and fill in project information to be inputted into the file templates. In turn, this provides the project sufficient structure and foundation to promote a healthy open source ecosystem
+The repo-scaffolder project creates repositories that adhere to open source hygiene standards and best practices. It provides templates and guidance for project metadata, contributing practices, community governance, feedback mechanisms, security policies, and more. Using [cookiecutter](https://github.com/cookiecutter/cookiecutter), repo-scaffolder helps teams identify what tier their project is classified as and fill in project information to be inputted into the file templates. In turn, this provides the project sufficient structure and foundation to promote a healthy open source ecosystem.
 
 This repository also includes [outbound checklists](#Outbound-Checklists) for each tier outlining the review process for releasing repositories as open source.
 
@@ -80,6 +80,22 @@ A list of core team members responsible for the code and documentation in this r
 
 ## Using repo-scaffolder
 
+##### Prerequisites
+
+- python
+- github cli
+- [cookiecutter](https://github.com/cookiecutter/cookiecutter)
+- [repolinter](https://github.com/todogroup/repolinter)
+
+###### Installation (On Mac)
+
+```
+python3 -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt
+brew install gh
+```
+
 ### 1. Identify your project's maturity model tier
 
 If you do not know what tier your project is, the `tier-determiner.py` script will walk you through questions to figure out what tier you need. Run:
@@ -118,22 +134,6 @@ Now that you identified your project's maturity model tier, use the command belo
 
 ```
 cookiecutter https://github.com/DSACMS/repo-scaffolder --directory=tierX
-```
-
-##### Prerequisites
-
-- python
-- github cli
-- [cookiecutter](https://github.com/cookiecutter/cookiecutter)
-- [repolinter](https://github.com/todogroup/repolinter)
-
-###### Installation (On Mac)
-
-```
-python3 -m venv venv
-. venv/bin/activate
-pip install -r requirements.txt
-brew install gh
 ```
 
 #### Add files to an existing repository using repolinter

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A list of core team members responsible for the code and documentation in this r
       - [Using repo-scaffolder](#add-files-to-an-existing-repository-using-repo-scaffolder)
 3. [Review your repository using outbound checklists](#3-review-your-repository-using-outbound-checklists)
     - [Add metadata to your project](#metadata-collection-using-codejson)
-4. [Maintaining your repository](#4-maintaining-your-repository-using-repo-scaffolder)
+4. [Maintain your repository](#4-maintain-your-repository-using-repo-scaffolder)
     - [GitHub Actions](#updating-repository-using-github-action-workflows)
     - [Upstream file changes](#Updating-projects-with-new-repo-scaffolder-upstream-file-changes)
 
@@ -88,6 +88,8 @@ If you do not know what tier your project is, the `tier-determiner.py` script wi
 python tier-determiner.py
 ```
 
+Alternatively, the landing page includes a [quiz](https://dsacms.github.io/repo-scaffolder/#maturity-model-tier-quiz) to determine your project's tier.
+
 You can also follow the flowchart below to determine your project's tier.
 ![Tier Selection Flowchart](./assets/images/flowchart.png)
 
@@ -112,7 +114,7 @@ The `/tier*` directory consists of templates, files, and scripts for each respec
 - `checklist.md` & `checklist.pdf` is the outbound review checklist with guidelines on releasing the repository as open source.
 - `README.md` with more information about the maturity tier and file contents.
 
-**Now that you identified your project's maturity model tier, use the command below to create a new repository, with `X` substituted for the tier number.**
+Now that you identified your project's maturity model tier, use the command below to create a new repository, with `X` substituted for the tier number.
 
 ```
 cookiecutter https://github.com/DSACMS/repo-scaffolder --directory=tierX
@@ -154,7 +156,6 @@ Sample commands to run with the given repolinter.json path:
 repolinter lint . # Runs on target directory
 
 repolinter lint . --config path/to/repolinter.json # Use if the repolinter config is not in the root dir
-
 ```
 
 ##### Use automated repolinter GitHub Actions to add files
@@ -171,7 +172,7 @@ For repositories that have already exist and are in active development, you can 
 4. Make sure when answering the questions you use the existing folder/project name
 5. Raise pr into main
 
-### 3. Review your repository using Outbound Checklists
+### 3. Review your repository using outbound checklists
 Before releasing your project as open source, follow the [outbound checklists](#outbound-checklists) to review your repository.
 
 #### Metadata collection using code.json
@@ -188,7 +189,7 @@ To add code.json into your project, navigate to your project's `.github` directo
 cookiecutter . --directory=codejson
 ```
 
-### 4. Maintaining your repository using repo-scaffolder
+### 4. Maintain your repository using repo-scaffolder
 
 #### Updating repository using GitHub Action workflows
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,17 @@ A list of core team members responsible for the code and documentation in this r
 
 ## Using repo-scaffolder
 
-### Create a new repository using repo-scaffolder
+### Create a new repository using repository templates
+
+Use our GitHub repository templates to create a repository of any tier:
+- [Tier 0](https://github.com/DSACMS/tier0)
+- [Tier 1](https://github.com/DSACMS/tier1)
+- [Tier 2](https://github.com/DSACMS/tier2)
+- [Tier 3](https://github.com/DSACMS/tier3)
+- [Tier 4](https://github.com/DSACMS/tier4)
+
+
+### Create a new repository using cookiecutter
 
 The Open Source Program Office follows a maturity model framework to classify federal repositories according to their level of maturity: https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ A list of core team members responsible for the code and documentation in this r
 4. [Maintaining your repository](#4-maintaining-your-repository-using-repo-scaffolder)
     - [GitHub Actions](#updating-repository-using-github-action-workflows)
     - [Upstream file changes](#Updating-projects-with-new-repo-scaffolder-upstream-file-changes)
+
 [Additional Documentation](./docs)
 
 ##### Maturity Models

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
                 <input class="usa-checkbox__input" id="check-maturity-model-tier" type="checkbox">
                 <label class="usa-checkbox__label" for="check-maturity-model-tier">
                   Use <a href="#maturity-model-tier-quiz">Maturity Model Tier Quiz</a> or
-                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#need-help-picking-a-maturity-tier"
+                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#1-identify-your-projects-maturity-model-tier"
                     target="_blank" rel="noopener noreferrer">tier-determiner</a>
                   script in repo-scaffolder
                 </label>
@@ -215,8 +215,8 @@
                 <input class="usa-checkbox__input" id="check-repo-creation-templates" type="checkbox">
                 <label class="usa-checkbox__label" for="check-repo-creation-templates">
                   Create a new repository using
-                  <a href="https://github.com/DSACMS/?q=tier&type=template&language=&sort=name" target="_blank"
-                    rel="noopener noreferrer">
+                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#create-a-new-repository-using-repository-templates"
+                    target="_blank" rel="noopener noreferrer">
                     repository templates</a>
                 </label>
               </div>
@@ -224,18 +224,30 @@
               <div class="usa-checkbox">
                 <input class="usa-checkbox__input" id="check-repo-creation-cookiecutter" type="checkbox">
                 <label class="usa-checkbox__label" for="check-repo-creation-cookiecutter">
-                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#Using-repo-scaffolder"
+                  Create a new repository by running
+                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#create-a-new-repository-using-repo-scaffolder"
                     target="_blank" rel="noopener noreferrer">
-                    Create a new repository</a> by running cookiecutter
+                    cookiecutter</a>
                 </label>
               </div>
               <p style="margin-top: 0.75rem;">OR</p>
               <div class="usa-checkbox">
                 <input class="usa-checkbox__input" id="check-existing-repo" type="checkbox">
                 <label class="usa-checkbox__label" for="check-existing-repo">
-                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#update-an-existing-repository-using-repo-scaffolder"
+                  Add files to an existing repository using
+                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#add-files-to-an-existing-repository-using-repolinter"
                     target="_blank" rel="noopener noreferrer">
-                    Add files to an existing repository</a> by running cookiecutter
+                    repolinter</a>
+                </label>
+              </div>
+              <p style="margin-top: 0.75rem;">OR</p>
+              <div class="usa-checkbox">
+                <input class="usa-checkbox__input" id="check-existing-repo" type="checkbox">
+                <label class="usa-checkbox__label" for="check-existing-repo">
+                  Add files to an existing repository by running
+                  <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#add-files-to-an-existing-repository-using-repo-scaffolder"
+                    target="_blank" rel="noopener noreferrer">
+                    cookiecutter</a>
                 </label>
               </div>
               <a href="#repository-templates" class="doc-link">
@@ -701,14 +713,14 @@
             <div class="doc-card">
               <h3>Cookiecutter</h3>
               <p>Create new repositories using file templates as your starting point.</p>
-              <a href="https://github.com/DSACMS/repo-scaffolder/tree/main?tab=readme-ov-file#using-repo-scaffolder"
+              <a href="https://github.com/DSACMS/repo-scaffolder/tree/main?tab=readme-ov-file#2-set-up-your-repository"
                 target="_blank" rel="noopener noreferrer" class="doc-link">View docs <span
                   aria-hidden="true">→</span></a>
             </div>
             <div class="doc-card">
               <h3>Repolinter</h3>
               <p>Identify missing files and content.</p>
-              <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#identify-missing-files-and-information-using-repolinter"
+              <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#add-files-to-an-existing-repository-using-repolinter"
                 target="_blank" rel="noopener noreferrer" class="doc-link">View docs <span
                   aria-hidden="true">→</span></a>
             </div>

--- a/index.html
+++ b/index.html
@@ -212,8 +212,18 @@
             </div>
             <div style="margin-left: 4em;">
               <div class="usa-checkbox">
-                <input class="usa-checkbox__input" id="check-benefits" type="checkbox">
-                <label class="usa-checkbox__label" for="check-benefits">
+                <input class="usa-checkbox__input" id="check-repo-creation-templates" type="checkbox">
+                <label class="usa-checkbox__label" for="check-repo-creation-templates">
+                  Create a new repository using
+                  <a href="https://github.com/DSACMS/?q=tier&type=template&language=&sort=name" target="_blank"
+                    rel="noopener noreferrer">
+                    repository templates</a>
+                </label>
+              </div>
+              <p style="margin-top: 0.75rem;">OR</p>
+              <div class="usa-checkbox">
+                <input class="usa-checkbox__input" id="check-repo-creation-cookiecutter" type="checkbox">
+                <label class="usa-checkbox__label" for="check-repo-creation-cookiecutter">
                   <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#Using-repo-scaffolder"
                     target="_blank" rel="noopener noreferrer">
                     Create a new repository</a> by running cookiecutter
@@ -221,8 +231,8 @@
               </div>
               <p style="margin-top: 0.75rem;">OR</p>
               <div class="usa-checkbox">
-                <input class="usa-checkbox__input" id="check-risks" type="checkbox">
-                <label class="usa-checkbox__label" for="check-risks">
+                <input class="usa-checkbox__input" id="check-existing-repo" type="checkbox">
+                <label class="usa-checkbox__label" for="check-existing-repo">
                   <a href="https://github.com/DSACMS/repo-scaffolder?tab=readme-ov-file#update-an-existing-repository-using-repo-scaffolder"
                     target="_blank" rel="noopener noreferrer">
                     Add files to an existing repository</a> by running cookiecutter

--- a/tier0/README.md
+++ b/tier0/README.md
@@ -6,6 +6,8 @@ A **Tier 0** project is an **experimental or historical** repository that is **p
 
 The main purpose of a Tier 0 project is to provide a space for initial development, exploration, and testing. These repositories generally lack formal documentation or governance structures that are typical of more mature projects.
 
+> The Tier 0 repository template can be found in [`{{cookiecutter.project_slug}}`](./{{cookiecutter.project_slug}}/) and is offered as a GitHub template repository: https://github.com/DSACMS/tier0
+
 ### Key Characteristics of a Tier 0 Project:
 
 - **Private** and often limited to individual or small team access.

--- a/tier1/README.md
+++ b/tier1/README.md
@@ -6,6 +6,8 @@ A **Tier 1** project refers to an **informational or historical** project that h
 
 The main purpose of a Tier 1 project is to share knowledge and provide information from past work. Though available for public consumption, the project is **not expected to evolve or expand** in the future. Contributors may not engage in continuous development or issue resolution.
 
+> The Tier 1 repository template can be found in [`{{cookiecutter.project_slug}}`](./{{cookiecutter.project_slug}}/) and is offered as a GitHub template repository: https://github.com/DSACMS/tier1
+
 ### Key Characteristics of a Tier 1 Project:
 
 - **Publicly released** without planned future development or maintenance.

--- a/tier2/README.md
+++ b/tier2/README.md
@@ -6,6 +6,8 @@ A **Tier 2** project is a **collaborative effort** that typically occurs within 
 
 Innersource projects often allow different teams within the same organization to contribute, fostering collaboration and code-sharing internally while maintaining control over external access.
 
+> The Tier 2 repository template can be found in [`{{cookiecutter.project_slug}}`](./{{cookiecutter.project_slug}}/) and is offered as a GitHub template repository: https://github.com/DSACMS/tier2
+
 ### Key Characteristics of a Tier 2 Project:
 
 - Focuses on **collaborating within a smaller team** or internal group.

--- a/tier3/README.md
+++ b/tier3/README.md
@@ -4,6 +4,8 @@
 
 A **Tier 3** project is an **open collaboration** effort where the work is conducted in public. The project is led by smaller, semi-open teams but encourages **limited external contributions**. The work is typically **open source**, but the direction and maintenance of the project are CMS-led, controlled by a smaller group or team, rather than a large, decentralized community. Tier 3 projects may be public-facing tools, utilities, or websites, where external contributions are welcomed but managed closely by the core team.
 
+> The Tier 3 repository template can be found in [`{{cookiecutter.project_slug}}`](./{{cookiecutter.project_slug}}/) and is offered as a GitHub template repository: https://github.com/DSACMS/tier3
+
 ### Key Characteristics of a Tier 3 Project:
 
 - **Collaborative in public**, where the work is open to external stakeholders.

--- a/tier4/README.md
+++ b/tier4/README.md
@@ -4,6 +4,8 @@
 
 A **Tier 4** project is a fully **open and collaborative** project that operates under a **community governance model**. In Tier 4 projects, the focus is on **collaborating broadly with the public**, and the project is often either **donated** to or **stewarded** by an external community. The governance structure is **open** and welcomes input from a wide range of contributors, typically from outside the original development team.
 
+> The Tier 4 repository template can be found in [`{{cookiecutter.project_slug}}`](./{{cookiecutter.project_slug}}/) and is offered as a GitHub template repository: https://github.com/DSACMS/tier4
+
 ### Key Characteristics of a Tier 4 Project:
 
 - **Broad public collaboration** with contributions welcomed from the community.


### PR DESCRIPTION
## Docs: Add repository journey content and repository templates

## Problem

I want to align the README with content from the repo-scaffolder landing page by structuring it similarly to the repository journey section. Additionally, I would like to add repository template content to all docs

## Solution

- Add repository journey content to README
- Added repository template content to README, tier READMEs, and landing page