### PR TITLE
Workflow: Add GitHub Action to sync repo-scaffolder templates with GitHub template repositories

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,111 @@
+DSACMS/tier1:
+  - source: ./tier1/{{cookiecutter.project_slug}}/LICENSE
+    dest: ./LICENSE
+  - source: ./tier1/{{cookiecutter.project_slug}}/README.md
+    dest: ./README.md
+  - source: ./tier1/{{cookiecutter.project_slug}}/COMMUNITY.md
+    dest: ./COMMUNITY.md
+  - source: ./tier1/{{cookiecutter.project_slug}}/SECURITY.md
+    dest: ./SECURITY.md
+  - source: ./tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+    dest: ./CONTRIBUTING.md
+  - source: ./tier1/{{cookiecutter.project_slug}}/repolinter.json
+    dest: ./repolinter.json
+  - source: ./tier1/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
+    dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier1/{{cookiecutter.project_slug}}/.github/workflows
+    dest: ./.github/workflows
+  - source: ./tier1/{{cookiecutter.project_slug}}/.github/codejson/hooks
+    dest: ./.github/codejson/hooks
+  - source: ./tier1/{{cookiecutter.project_slug}}/.github/codejson/{{cookiecutter.project_name}}
+    dest: ./.github/codejson/{{cookiecutter.project_name}}
+  - source: ./tier1/{{cookiecutter.project_slug}}/.github/cookiecutter.json
+    dest: ./.github/codejson/cookiecutter.json
+
+DSACMS/tier2:
+  - source: ./tier2/{{cookiecutter.project_slug}}/LICENSE
+    dest: ./LICENSE
+  - source: ./tier2/{{cookiecutter.project_slug}}/README.md
+    dest: ./README.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/COMMUNITY.md
+    dest: ./COMMUNITY.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/SECURITY.md
+    dest: ./SECURITY.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+    dest: ./CONTRIBUTING.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+    dest: ./CODE_OF_CONDUCT.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/repolinter.json
+    dest: ./repolinter.json
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
+    dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/workflows
+    dest: ./.github/workflows
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+    dest: ./.github/CODEOWNERS.md
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/codejson/hooks
+    dest: ./.github/codejson/hooks
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/codejson/{{cookiecutter.project_name}}
+    dest: ./.github/codejson/{{cookiecutter.project_name}}
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/cookiecutter.json
+    dest: ./.github/codejson/cookiecutter.json
+
+DSACMS/tier3:
+  - source: ./tier3/{{cookiecutter.project_slug}}/LICENSE
+    dest: ./LICENSE
+  - source: ./tier3/{{cookiecutter.project_slug}}/README.md
+    dest: ./README.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
+    dest: ./COMMUNITY.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/SECURITY.md
+    dest: ./SECURITY.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+    dest: ./CONTRIBUTING.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+    dest: ./CODE_OF_CONDUCT.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/GOVERNANCE.md
+    dest: ./GOVERNANCE.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/repolinter.json
+    dest: ./repolinter.json
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
+    dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/workflows
+    dest: ./.github/workflows
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+    dest: ./.github/CODEOWNERS.md
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/codejson/hooks
+    dest: ./.github/codejson/hooks
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/codejson/{{cookiecutter.project_name}}
+    dest: ./.github/codejson/{{cookiecutter.project_name}}
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/cookiecutter.json
+    dest: ./.github/codejson/cookiecutter.json
+
+DSACMS/tier4:
+  - source: ./tier4/{{cookiecutter.project_slug}}/LICENSE
+    dest: ./LICENSE
+  - source: ./tier4/{{cookiecutter.project_slug}}/README.md
+    dest: ./README.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
+    dest: ./COMMUNITY.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/SECURITY.md
+    dest: ./SECURITY.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+    dest: ./CONTRIBUTING.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/CODE_OF_CONDUCT.md
+    dest: ./CODE_OF_CONDUCT.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/GOVERNANCE.md
+    dest: ./GOVERNANCE.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/repolinter.json
+    dest: ./repolinter.json
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
+    dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/workflows
+    dest: ./.github/workflows
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
+    dest: ./.github/CODEOWNERS.md
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/codejson/hooks
+    dest: ./.github/codejson/hooks
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/codejson/{{cookiecutter.project_name}}
+    dest: ./.github/codejson/{{cookiecutter.project_name}}
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/cookiecutter.json
+    dest: ./.github/codejson/cookiecutter.json

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,3 +1,21 @@
+DSACMS/tier0:
+  - source: ./tier0/{{cookiecutter.project_slug}}/LICENSE
+    dest: ./LICENSE
+  - source: ./tier0/{{cookiecutter.project_slug}}/README.md
+    dest: ./README.md
+  - source: ./tier0/{{cookiecutter.project_slug}}/COMMUNITY.md
+    dest: ./COMMUNITY.md
+  - source: ./tier0/{{cookiecutter.project_slug}}/repolinter.json
+    dest: ./repolinter.json
+  - source: ./tier0/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
+    dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier0/{{cookiecutter.project_slug}}/.github/codejson/hooks
+    dest: ./.github/codejson/hooks
+  - source: ./tier0/{{cookiecutter.project_slug}}/.github/codejson/{{cookiecutter.project_name}}
+    dest: ./.github/codejson/{{cookiecutter.project_name}}
+  - source: ./tier0/{{cookiecutter.project_slug}}/.github/cookiecutter.json
+    dest: ./.github/codejson/cookiecutter.json
+
 DSACMS/tier1:
   - source: ./tier1/{{cookiecutter.project_slug}}/LICENSE
     dest: ./LICENSE

--- a/.github/workflows/syncTemplateRepos.yml
+++ b/.github/workflows/syncTemplateRepos.yml
@@ -1,0 +1,16 @@
+name: Sync Template Repos
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@main
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@latest
+        with:
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/syncTemplateRepos.yml
+++ b/.github/workflows/syncTemplateRepos.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@latest
         with:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_PAT: ${{ secrets.GH_PAT_FOR_SYNC }}

--- a/.github/workflows/syncTemplateRepos.yml
+++ b/.github/workflows/syncTemplateRepos.yml
@@ -1,4 +1,7 @@
 name: Sync Template Repos
+permissions:
+  contents: write
+  pull-requests: write
 on:
   push:
     branches:


### PR DESCRIPTION
## Workflow: Add GitHub Action to sync repo-scaffolder templates with GitHub template repositories

## Problem

Currently, if a change is made to our repository templates in repo-scaffolder, we would have to manually make this update and sync up our GitHub template repositories. We would like to use a GitHub Action that automatically syncs changes between repo-scaffolder templates and our template repostiories.

## Solution

- Use [`repo-file-sync-action`](https://github.com/marketplace/actions/repo-file-sync-action) to sync up changes from repo-scaffolder to our template repositories

## Result
When a change has been made to a template and this has been merged to main, this triggers this workflow where a PR will be made to the GitHub template repository adding this change, syncing up the template repository with repo-scaffolder main.

Still some open-ended questions
- Do we want to auto-merge these PRs or still undergo a review instead?
- TODO @natalialuzuriaga : Draft a PR message and commit messages, look into PR settings
- TODO @natalialuzuriaga : Create and add PAT to repository


## Test Plan
Did testing on a fork and here is a PR that syncs up changes between natalialuzuriaga/repo-scaffolder and natalialuzuriaga/tier1: https://github.com/natalialuzuriaga/tier1/pull/6