### PR TITLE
Repolinter: Remove old COMMUNITY_GUIDELINES.md rules

### DIFF
--- a/tier0/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier0/{{cookiecutter.project_slug}}/repolinter.json
@@ -77,17 +77,6 @@
         }
       }
     },
-    "community-guidelines-file-exists": {
-      "level": "off",
-      "rule": {
-        "type": "file-existence",
-        "options": {
-          "globsAny": ["{docs/,.github/,}COMMUNITY_GUIDELINES.md"],
-          "file-name": "COMMUNITY_GUIDELINES.md",
-          "file-content": "# {name_of_project_here} Open Source Community Guidelines \nThis document contains principles and guidelines for participating in the {name_of_project_here} open source community. \n"
-        }
-      }
-    },
     "code-of-conduct-file-exists": {
       "level": "off",
       "rule": {
@@ -329,7 +318,7 @@
           "content": "Community Guidelines",
           "flags": "i",
           "file-name": "README.md",
-          "file-content": "## Community Guidelines \nPrinciples and guidelines for participating in our open source community are can be found in [COMMUNITY_GUIDELINES.md](COMMUNITY_GUIDELINES.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. \n"
+          "file-content": "## Community Guidelines \nPrinciples and guidelines for participating in our open source community are can be found in [COMMUNITY.md](COMMUNITY.md). Please read them before joining or starting a conversation in this repo or one of the channels listed below. All community members and participants are expected to adhere to the community guidelines and code of conduct when participating in community spaces including: code repositories, communication channels and venues, and events. \n"
         }
       }
     },
@@ -667,46 +656,7 @@
           "content": "Governance",
           "flags": "i",
           "file-name": "GOVERNANCE.md",
-          "file-content": "# Governance \n<!-- TODO: Starting at Tier 3 GOVERNANCE.md has basic language about early community governance, how the project make decisions, and how contributors are elevated through the leadership process if any (e.g. joining teams, getting maintainer status, etc...)--> \n This project is governed by our [Community Guidelines](COMMUNITY_GUIDELINES.md) and [Code of Conduct](CODE_OF_CONDUCT.md). \n"
-        }
-      }
-    },
-    "community-guidelines-contains-principles": {
-      "level": "off",
-      "rule": {
-        "type": "file-contents",
-        "options": {
-          "globsAll": ["{docs/,.github/,}COMMUNITY_GUIDELINES.md"],
-          "content": "Principles",
-          "flags": "i",
-          "file-name": "COMMUNITY_GUIDELINES.md",
-          "file-content": "## Principles \nThese principles guide our data, product, and process decisions, architecture, and approach.\n- Open means transparent and participatory.\n- We take a modular and modern approach to software development.\n- We build open-source software and open-source process.\n- We value ease of implementation.\n- Fostering community includes building capacity and making our software and processes accessible to participants with diverse backgrounds and skillsets.\n- Data (and data science) is as important as software and process. We build open data sets where possible.\n- We strive for transparency for algorithms and places we might be introducing bias. \n"
-        }
-      }
-    },
-    "community-guidelines-contains-community-guidelines": {
-      "level": "off",
-      "rule": {
-        "type": "file-contents",
-        "options": {
-          "globsAll": ["{docs/,.github/,}COMMUNITY_GUIDELINES.md"],
-          "content": "Community Guidelines",
-          "flags": "i",
-          "file-name": "COMMUNITY_GUIDELINES.md",
-          "file-content": "## Community Guidelines \nAll community members are expected to adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).\nInformation on contributing to this repository is available in our [Contributing file](CONTRIBUTING.md).\nWhen participating in {{ cookiecutter.project_name }} open source community conversations and spaces, we ask individuals to follow the following guidelines:\n- When joining a conversation for the first time, please introduce yourself by providing a brief intro that includes:\n  - your related organization (if applicable)\n  - your pronouns\n  - your superpower, and how you hope to use it for {{ cookiecutter.project_name }}\n- Embrace a culture of learning, and educate each other. We are all entering this conversation from different starting points and with different backgrounds. There are no dumb questions.\n- Take space and give space. We strive to create an equitable environment in which all are welcome and able to participate. We hope individuals feel comfortable voicing their opinions and providing contributions and will do our best to recognize and make space for individuals who may be struggling to find space here. Likewise, we expect individuals to recognize when they are taking up significant space and take a step back to allow room for others.\n<!-- TODO: Add if your repo has a community chat - Be present when joining synchronous conversations such as our community chat. Why be here if you're not going to *be here*? -->\n- Be respectful.\n- Default to positive. Assume others' contributions are legitimate and valuable and that they are made with good intention.\n"
-        }
-      }
-    },
-    "community-guidelines-contains-acknowledgements": {
-      "level": "off",
-      "rule": {
-        "type": "file-contents",
-        "options": {
-          "globsAll": ["{docs/,.github/,}COMMUNITY_GUIDELINES.md"],
-          "content": "Acknowledgements",
-          "flags": "i",
-          "file-name": "COMMUNITY_GUIDELINES.md",
-          "file-content": "## Acknowledgements \nThis COMMUNITY_GUIDELINES.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.\n"
+          "file-content": "# Governance \n<!-- TODO: Starting at Tier 3 GOVERNANCE.md has basic language about early community governance, how the project make decisions, and how contributors are elevated through the leadership process if any (e.g. joining teams, getting maintainer status, etc...)--> \n This project is governed by our [Community Guidelines](COMMUNITY.md) and [Code of Conduct](CODE_OF_CONDUCT.md). \n"
         }
       }
     },

--- a/tier2/{{cookiecutter.project_slug}}/repolinter.json
+++ b/tier2/{{cookiecutter.project_slug}}/repolinter.json
@@ -14,9 +14,6 @@
     "code-of-conduct-file-exists": {
       "level": "error"
     },
-    "community-guidelines-file-exists": {
-      "level": "error"
-    },
     "readme-contains-project-vision": {
       "level": "error"
     },


### PR DESCRIPTION
## Repolinter: Remove old COMMUNITY_GUIDELINES.md rules

## Problem

`COMMUNITY_GUIDELINES.md` is no longer a required file according to our maturity model framework, thus we would like to remove its rules in our `repolinter.json`

## Solution

Removed:
- `"community-guidelines-file-exists"`
- `"community-guidelines-contains-principles"`
- `"community-guidelines-contains-community-guidelines"`
- `"community-guidelines-contains-acknowledgements"`
- mentions of `COMMUNITY_GUIDELINES.md`