### PR TITLE
Repository Templates: Add PR template

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -57,6 +57,8 @@ DSACMS/tier2:
     dest: ./repolinter.json
   - source: ./tier2/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
     dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier2/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
+    dest: ./.github/PULL_REQUEST_TEMPLATE.md
   - source: ./tier2/{{cookiecutter.project_slug}}/.github/workflows
     dest: ./.github/workflows
   - source: ./tier2/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
@@ -87,6 +89,8 @@ DSACMS/tier3:
     dest: ./repolinter.json
   - source: ./tier3/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
     dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier3/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
+    dest: ./.github/PULL_REQUEST_TEMPLATE.md
   - source: ./tier3/{{cookiecutter.project_slug}}/.github/workflows
     dest: ./.github/workflows
   - source: ./tier3/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md
@@ -117,6 +121,8 @@ DSACMS/tier4:
     dest: ./repolinter.json
   - source: ./tier4/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE
     dest: ./.github/ISSUE_TEMPLATE
+  - source: ./tier4/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
+    dest: ./.github/PULL_REQUEST_TEMPLATE.md
   - source: ./tier4/{{cookiecutter.project_slug}}/.github/workflows
     dest: ./.github/workflows
   - source: ./tier4/{{cookiecutter.project_slug}}/.github/CODEOWNERS.md

--- a/tier2/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tier2/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thank you for sending the PR! We appreciate you spending the time to work on
+these changes.
+
+Help us understand your motivation by explaining why you decided to make this change.
+
+Happy contributing!
+
+- Comments should be formatted to a width no greater than 80 columns.
+
+- Files should be exempt of trailing spaces.
+
+- We adhere to a specific format for commit messages. Please write your commit
+messages along these guidelines. Please keep the line width no greater than 80
+columns (You can use `fmt -n -p -w 80` to accomplish this).
+
+
+-->
+
+## module-name: One line description of your change (less than 72 characters)
+
+## Problem
+
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of being the motivation for your change.
+
+## Solution
+
+Describe the modifications you've done.
+
+## Result
+
+What will change as a result of your pull request? Note that sometimes this
+section is unnecessary because it is self-explanatory based on the solution.
+
+Some important notes regarding the summary line:
+
+* Describe what was done; not the result 
+* Use the active voice 
+* Use the present tense 
+* Capitalize properly 
+* Do not end in a period — this is a title/subject 
+* Prefix the subject with its scope
+
+## Test Plan
+
+(Write your test plan here. If you changed any code, please provide us with
+clear instructions on how you verified your changes work.)

--- a/tier4/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/tier4/{{cookiecutter.project_slug}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thank you for sending the PR! We appreciate you spending the time to work on
+these changes.
+
+Help us understand your motivation by explaining why you decided to make this change.
+
+Happy contributing!
+
+- Comments should be formatted to a width no greater than 80 columns.
+
+- Files should be exempt of trailing spaces.
+
+- We adhere to a specific format for commit messages. Please write your commit
+messages along these guidelines. Please keep the line width no greater than 80
+columns (You can use `fmt -n -p -w 80` to accomplish this).
+
+
+-->
+
+## module-name: One line description of your change (less than 72 characters)
+
+## Problem
+
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of being the motivation for your change.
+
+## Solution
+
+Describe the modifications you've done.
+
+## Result
+
+What will change as a result of your pull request? Note that sometimes this
+section is unnecessary because it is self-explanatory based on the solution.
+
+Some important notes regarding the summary line:
+
+* Describe what was done; not the result 
+* Use the active voice 
+* Use the present tense 
+* Capitalize properly 
+* Do not end in a period — this is a title/subject 
+* Prefix the subject with its scope
+
+## Test Plan
+
+(Write your test plan here. If you changed any code, please provide us with
+clear instructions on how you verified your changes work.)


### PR DESCRIPTION
## Repository Templates: Add PR template

## Problem
We would like to add PR templates to Tier 2-4.

## Solution

- Added PR templates to Tier 2, 4. Already exists in Tier 3
- Add PR template files to `sync.yml` to sync file changes with github template repositories