### PR TITLE
Workflow: Update Auto-Changelog Action

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -7,7 +7,19 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: "Auto Generate changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+       - name: Checkout code
+         uses: actions/checkout@v4
+         with:
+           ref: main
+       - name: "Auto Generate changelog"
+         uses: heinrichreimer/action-github-changelog-generator@v2.3
+         with:
+           issues: true
+           issuesWoLabels: true
+           pullRequests: true
+           prWoLabels: true
+           token: ${{ secrets.GITHUB_TOKEN }}
+       - uses: stefanzweifel/git-auto-commit-action@v4
+         with:
+           commit_message: Update Changelog with new release
+           file_pattern: CHANGELOG.md

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -7,9 +7,17 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: "Auto Generate changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
+       - name: Checkout code
+         uses: actions/checkout@v4
+         with:
+           ref: main
+       - name: "Auto Generate changelog"
+         uses: heinrichreimer/action-github-changelog-generator@v2.3
+         with:
           {% raw %}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+           token: ${{ secrets.GITHUB_TOKEN }}
+           {% endraw %}
+       - uses: stefanzweifel/git-auto-commit-action@v4
+         with:
+           commit_message: Update Changelog with new release
+           file_pattern: CHANGELOG.md

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -7,9 +7,17 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: "Auto Generate changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
-          {% raw %}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+       - name: Checkout code
+         uses: actions/checkout@v4
+         with:
+           ref: main
+       - name: "Auto Generate changelog"
+         uses: heinrichreimer/action-github-changelog-generator@v2.3
+         with:
+           {% raw %}
+           token: ${{ secrets.GITHUB_TOKEN }}
+           {% endraw %}
+       - uses: stefanzweifel/git-auto-commit-action@v4
+         with:
+           commit_message: Update Changelog with new release
+           file_pattern: CHANGELOG.md

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -7,9 +7,17 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - name: "Auto Generate changelog"
-        uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
-          {% raw %}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          {% endraw %}
+       - name: Checkout code
+         uses: actions/checkout@v4
+         with:
+           ref: main
+       - name: "Auto Generate changelog"
+         uses: heinrichreimer/action-github-changelog-generator@v2.3
+         with:
+           {% raw %}
+           token: ${{ secrets.GITHUB_TOKEN }}
+           {% endraw %}
+       - uses: stefanzweifel/git-auto-commit-action@v4
+         with:
+           commit_message: Update Changelog with new release
+           file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Workflow: Update Auto-Changelog Action

## Problem

Currently, the auto-changelog action generates a changelog however it doesn't actually commit these results to `CHANGELOG.md`. This PR adds a step in the workflow to commit the edits of the file.

## Solution

For the repository's workflow file along with workflow files in Tiers 2-4:
- Add a step that checks outs the code
- Add a step after changelog generation that commits the edits to `CHANGELOG.md`

## Result

When a new release is created, the changelog is generated and makes a commit that updates the `CHANGELOG.md` file accordingly

## Test Plan

Tested and works in my fork: https://github.com/natalialuzuriaga/repo-scaffolder/blob/main/CHANGELOG.md
