### PR TITLE
Add pointer to GitHub guides

### DIFF
--- a/tier1/checklist.md
+++ b/tier1/checklist.md
@@ -33,6 +33,8 @@ This is a review process to approve CMS-developed software to be released open s
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
 
 ### Prerequisites
+**Your project should be stored in a GitHub repository**
+If you are new to GitHub or repositories, checkout the OSPO's [Beginner Guide to Creating GitHub Repos](https://dsacms.github.io/ospo-guide/resources/beginner-guide-github-repos/) before moving on to the next steps.
 
 Does your repository align with the requirements of a Tier 1 project? To verify:
 

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -33,6 +33,8 @@ This is a review process to approve CMS-developed software to be released open s
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
 
 ### Prerequisites
+**Your project should be stored in a GitHub repository**
+If you are new to GitHub or repositories, checkout the OSPO's [Beginner Guide to Creating GitHub Repos](https://dsacms.github.io/ospo-guide/resources/beginner-guide-github-repos/) before moving on to the next steps.
 
 Does your repository align with the requirements of a Tier 2 project? To verify:
 

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -36,6 +36,8 @@ If you would like your repository to be released, please complete the following 
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
 
 ### Prerequisites
+**Your project should be stored in a GitHub repository**
+If you are new to GitHub or repositories, checkout the OSPO's [Beginner Guide to Creating GitHub Repos](https://dsacms.github.io/ospo-guide/resources/beginner-guide-github-repos/) before moving on to the next steps.
 
 Does your repository align with the requirements of a Tier 3 project? To verify:
 

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -38,6 +38,8 @@ If you would like your repository to be released, please complete the following 
 [Flipping the Switch: Making the Repository Public](#flipping-the-switch-making-the-repository-public)
 
 ### Prerequisites
+**Your project should be stored in a GitHub repository**
+If you are new to GitHub or repositories, checkout the OSPO's [Beginner Guide to Creating GitHub Repos](https://dsacms.github.io/ospo-guide/resources/beginner-guide-github-repos/) before moving on to the next steps.
 
 Does your repository align with the requirements of a Tier 4 project? To verify:
 


### PR DESCRIPTION
## module-name: Add pointer to OSPO Guide

## Problem
Beginner GitHub and repository users are expected to understand repository creation in order to do a repo review, without any background.

## Solution
Create a guide to explain repo creation and usage. Point to the guide in repo-scaffolder.

## Result
Now, if a user is not familiar with GitHub or creating repositories, but is expected to do a code review of a repo, they will have guidance.

## Test Plan
Test in browser
