### PR TITLE
Workflows: Add content permissions to auto-changelog.yml

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+permissions:
+  contents: write
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+permissions:
+  contents: write
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+permissions:
+  contents: write
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/auto-changelog.yml
@@ -3,6 +3,8 @@ on:
   release:
     types:
       - created
+permissions:
+  contents: write
 jobs:
   changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Workflows: Add content permissions to auto-changelog.yml

## Problem

When creating the release, the `auto-changelog.yml` workflow failed due to `GITHUB_TOKEN` missing write permissions.

## Solution

- Add `contents: write` permissions to `auto-changelog.yml` workflow files in repo-scaffolder itself along with the templates

## Result
`auto-changelog.yml` should run successfully now!

## Test Plan
Works in personal fork
