### PR TITLE
Tests: Create tests using pytest-cookies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on: 
+    push:
+        branches: [ main ]
+        paths:
+            - "tests/**"
+            - "tier*/**"
+    pull_request:
+        types: [ opened, synchronize ]
+        paths:
+            - "tests/**"
+            - "tier*/**"
+
+permissions:
+    contents: read
+
+jobs:
+    run-tests:
+        name: Run Tests
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: '3.9'
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+
+            - name: Run Tests
+              run: |
+                  pytest --template tier0
+                  pytest --template tier1
+                  pytest --template tier2
+                  pytest --template tier3
+                  pytest --template tier4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Files ignored because they're binary/unnecessary
 .DS_STORE
+
 # Files/Dirs ignored because they're secret/internal only
 id_rsa
 secrets_repo/
 internal_only_repo/
+
+# Python
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 cookiecutter==2.6.0
+pytest-cookies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 import pytest
 
 @pytest.fixture
-def context():
-    return {
+def template_tier(request):
+    template = request.config.getoption("--template")
+    return int(template[-1])
+
+@pytest.fixture
+def context(template_tier):
+    context = {
         "project_name": "Web Dashboard",
         "project_slug": "web_dashboard",
         "project_org": "DSACMS",
@@ -13,6 +18,12 @@ def context():
         "receive_updates": False,
         "add_team": False
     }
+    if template_tier == 3 or template_tier == 4:
+        context.update({
+            "code_owners": "",
+            "add_maintainer": False
+        })
+    return context
 
 @pytest.fixture
 def result(cookies, context):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,4 +16,4 @@ def context():
 
 @pytest.fixture
 def result(cookies, context):
-    return cookies.bake(template="./tier1",extra_context={**context})
+    return cookies.bake(extra_context={**context})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,5 +26,6 @@ def context(template_tier):
     return context
 
 @pytest.fixture
-def result(cookies, context):
-    return cookies.bake(extra_context={**context})
+def bakery(cookies_session, context):
+    result = cookies_session.bake(extra_context={**context})
+    yield result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+@pytest.fixture
+def context():
+    return {
+        "project_name": "Web Dashboard",
+        "project_slug": "web_dashboard",
+        "project_org": "DSACMS",
+        "project_repo_name": "web-dashboard",
+        "project_description": "This is a web dashboard.",
+        "project_visibility": "private",
+        "create_repo": False,
+        "receive_updates": False,
+        "add_team": False
+    }
+
+@pytest.fixture
+def result(cookies, context):
+    return cookies.bake(template="./tier1",extra_context={**context})

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -6,14 +6,12 @@ from binaryornot.check import is_binary
 
 PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
 RE_OBJ = re.compile(PATTERN)
-print(os.getcwd(), "hi")
 
 # Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
 def check_paths(paths):
     """Method to check all paths have correct substitutions."""
     # Assert that no match is found in any of the files
     for path in paths:
-        print(str(path), "hi")
         path_obj = Path(path)
 
         if is_binary(str(path)) or ".git" in path_obj.parts:
@@ -29,7 +27,6 @@ def check_paths(paths):
             match = RE_OBJ.search(line)
             assert match is None, f"cookiecutter variable not replaced in {path}"
 
-
 # Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
 def build_files_list(root_dir):
     """Build a list containing absolute paths to the generated files."""
@@ -38,7 +35,6 @@ def build_files_list(root_dir):
         for dirpath, _, files in os.walk(root_dir)
         for file_path in files
     ]
-
 
 def check_temp_paths_are_removed(result):
     temp_paths = [
@@ -58,8 +54,14 @@ def test_project_generation(context, result):
     assert result.project_path.name == context["project_slug"]
     assert result.project_path.is_dir()
 
+
     check_temp_paths_are_removed(result)
 
     paths = build_files_list(result.project_path)
     assert paths
+
+    # Specific checks for codejson cookiecutter files
+    assert Path(result.project_path)/".github/codejson/cookiecutter.json" in paths
+    assert Path(result.project_path)/".github/cookiecutter.json" not in paths
+
     check_paths(paths)

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -1,0 +1,65 @@
+import os
+import re
+from pathlib import Path
+
+from binaryornot.check import is_binary
+
+PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
+RE_OBJ = re.compile(PATTERN)
+print(os.getcwd(), "hi")
+
+# Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
+def check_paths(paths):
+    """Method to check all paths have correct substitutions."""
+    # Assert that no match is found in any of the files
+    for path in paths:
+        print(str(path), "hi")
+        path_obj = Path(path)
+
+        if is_binary(str(path)) or ".git" in path_obj.parts:
+            print("SKIP BINARY")
+            continue
+
+        if ".github" in path_obj.parts:
+            print("SKIP .github")
+            continue
+
+        print("OPEN FILE")
+        for line in path.open("r", encoding="utf-8"):
+            match = RE_OBJ.search(line)
+            assert match is None, f"cookiecutter variable not replaced in {path}"
+
+
+# Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
+def build_files_list(root_dir):
+    """Build a list containing absolute paths to the generated files."""
+    return [
+        Path(dirpath) / file_path
+        for dirpath, _, files in os.walk(root_dir)
+        for file_path in files
+    ]
+
+
+def check_temp_paths_are_removed(result):
+    temp_paths = [
+        result.project_path / "templates",
+    ]
+
+    for temp_path in temp_paths:
+        assert not temp_path.exists()
+
+
+# Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
+def test_project_generation(context, result):
+    """Test that project is generated and fully rendered."""
+
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert result.project_path.name == context["project_slug"]
+    assert result.project_path.is_dir()
+
+    check_temp_paths_are_removed(result)
+
+    paths = build_files_list(result.project_path)
+    assert paths
+    check_paths(paths)

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -1,7 +1,6 @@
 import os
 import re
 from pathlib import Path
-
 from binaryornot.check import is_binary
 
 PATTERN = r"{{(\s?cookiecutter)[.](.*?)}}"
@@ -44,24 +43,23 @@ def check_temp_paths_are_removed(result):
     for temp_path in temp_paths:
         assert not temp_path.exists()
 
-
-# Source: https://github.com/cookiecutter/cookiecutter-django/blob/f8897bfdff9681a28bc07b3361ab51bddb71a27c/tests/test_cookiecutter_generation.py
-def test_project_generation(context, result):
+def test_project_generation(context, bakery):
     """Test that project is generated and fully rendered."""
 
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert result.project_path.name == context["project_slug"]
-    assert result.project_path.is_dir()
+    assert bakery.exit_code == 0
+    assert bakery.exception is None
+    assert bakery.project_path.name == context["project_slug"]
+    assert bakery.project_path.is_dir()
 
 
-    check_temp_paths_are_removed(result)
-
-    paths = build_files_list(result.project_path)
+    check_temp_paths_are_removed(bakery)
+    paths = build_files_list(bakery.project_path)
     assert paths
 
+    print(bakery.project_path, "before codejson generation")
+
     # Specific checks for codejson cookiecutter files
-    assert Path(result.project_path)/".github/codejson/cookiecutter.json" in paths
-    assert Path(result.project_path)/".github/cookiecutter.json" not in paths
+    assert Path(bakery.project_path)/".github/codejson/cookiecutter.json" in paths
+    assert Path(bakery.project_path)/".github/cookiecutter.json" not in paths
 
     check_paths(paths)


### PR DESCRIPTION
## Tests: Create tests using pytest-cookies

## Problem

We would like to create tests for our repository templates to ensure that templates can be successfully generated without error as we make updates to them going forward.

## Solution

- Use pytest-cookies to create tests verifying content of templates in the following ways:
  - Assess the project has been generated through exit codes and existence of new directory
  - Check temp files have been removed
  - Verify that all cookiecutter variables have been replaced using the `check_paths` function
- Updated `.gitignore` to include `pycache` files

## Result

When users run `pytest --template $TIER_DIRECTORY`, all tests should pass for all tiers. Example: `pytest --template tier3`

Next up is adding codejson cookiecutter tests and unit tests for post_gen_hook.py

## Test Plan
Created `test.yml` to run checks upon every PR. Tests are passing as shown below!