### PR TITLE
Workflow: Update contributors.yml with fix and update contributor count in COMMUNITY.md

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,9 +2,6 @@ name: Update Contributors Information
 
 on:
   workflow_dispatch: {}
-  schedule:
-    # Weekly on Saturdays.
-    - cron: "30 1 * * 6"
   push:
     branches: [main]
 
@@ -19,55 +16,56 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  
-          token: ${{ secrets.PUSH_TO_PROTECTED_BRANCH }}
+          fetch-depth: 0
+
+      - name: Check if update needed
+        id: check_changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
+          REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
+          
+          CURRENT=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$OWNER/$REPO/contributors?per_page=100" | \
+            jq -r '[.[] | select(.type != "Bot" and (.login | test("\\[bot\\]$") | not) and (.login | test("-bot$") | not)) | .login] | sort | join(",")')
+          
+          EXISTING=$(grep -oP '(?<=github.com/)[^"]+(?=">)' COMMUNITY.md | \
+            grep -v "^$" | sort | uniq | tr '\n' ',' | sed 's/,$//')
+          
+          echo "Current contributors: $CURRENT"
+          echo "Existing contributors: $EXISTING"
+          
+          if [ "$CURRENT" = "$EXISTING" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No new contributors found. Skipping update!"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "New contributors detected. Running update!"
+          fi
 
       - name: Update contributor list
-        id: contrib_list
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: update_contributors
         uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
-          
-          GITHUB_TOKEN: ${{ secrets.PUSH_TO_PROTECTED_BRANCH }}
-          
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           readme_path: COMMUNITY.md
-          use_username: false
-          commit_message: "update contributors information"
-          auto_detect_branch_protection: false
+          commit_message: "updating contributors list"
+          pr_title_on_protected: "docs: update contributors information"
+          committer_username: "github-actions[bot]"
+          committer_email: "github-actions[bot]@users.noreply.github.com"
 
-      - name: Get contributors count
-        id: get_contributors
+      - name: Update PR
+        if: steps.check_changes.outputs.has_changes == 'true' && steps.update_contributors.outputs.pr_id != ''
         env:
-          
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-
         run: |
-            OWNER=$(echo $GITHUB_REPOSITORY | cut -d'/' -f1)
-            REPO=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)
-            QUERY='query { repository(owner: \"'"$OWNER"'\", name: \"'"$REPO"'\") { collaborators { totalCount } } }'
-
-            CONTRIBUTORS=$(gh api \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/repos/$OWNER/$REPO/contributors?per_page=100" | \
-              jq '[.[] | select(.type != "Bot" and (.login | test("\\[bot\\]$") | not) and (.login | test("-bot$") | not))] | length')
-
-            echo "Total contributors: $CONTRIBUTORS"
-            echo "contributors=$CONTRIBUTORS" >> $GITHUB_OUTPUT
-
-
-      - name: Update COMMUNITY.md
-        run: |
+          PR_NUMBER="${{ steps.update_contributors.outputs.pr_id }}"
           
-          CONTRIBUTORS="${{ steps.get_contributors.outputs.contributors }}"
-          
-
-          perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
-
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git pull
-          git add COMMUNITY.md
-          git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
-          git push
+          gh pr edit $PR_NUMBER \
+            --body "New contributors detected! This PR updates the contributors list in COMMUNITY.md." \
+            --add-label "documentation"

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -43,7 +43,7 @@ The members of the repo-scaffolder community are responsible for guiding its dev
 
 <!-- TODO: A list of CONTRIBUTORS is generated below using contributors.yml located in the workflows directory. In order to automatically update the COMMUNITY.md, you must enter a secret into your Secrets and Variables under Actions within your repository settings. The name of the secret must be PUSH_TO_PROTECTED_BRANCH and the value must be a Personal Access Token with specific permissions. Please follow [this link](https://github.com/CasperWA/push-protected?tab=readme-ov-file#notes-on-token-and-user-permissions) for more information. -->
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--> <!--CONTRIBUTOR COUNT END-->
+![](https://img.shields.io/github/contributors/DSACMS/repo-scaffolder?style=flat-square&label=Contributor%20Count(incl.%20bots)) 
 
 <!-- readme: contributors -start -->
 <table>

--- a/tier2/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier2/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -59,7 +59,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on the release process.
 
 TODO: A list of CONTRIBUTORS is generated below using contributors.yml located in the workflows directory. In order to automatically update the COMMUNITY.md, you must enter a secret into your Secrets and Variables under Actions within your repository settings. The name of the secret must be PUSH_TO_PROTECTED_BRANCH and the value must be a Personal Access Token with specific permissions. Please follow [this link](https://github.com/CasperWA/push-protected?tab=readme-ov-file#notes-on-token-and-user-permissions) for more information.
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--> <!--CONTRIBUTOR COUNT END-->
+![](https://img.shields.io/github/contributors/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}?style=flat-square&label=Contributor%20Count(incl.%20bots)) 
 
 <!-- readme: contributors -start -->
 <!-- readme: contributors -end -->

--- a/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier3/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -57,7 +57,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on the release process.
 
 <!-- TODO: A list of CONTRIBUTORS is generated below using contributors.yml located in the workflows directory. In order to automatically update the COMMUNITY.md, you must enter a secret into your Secrets and Variables under Actions within your repository settings. The name of the secret must be PUSH_TO_PROTECTED_BRANCH and the value must be a Personal Access Token with specific permissions. Please follow [this link](https://github.com/CasperWA/push-protected?tab=readme-ov-file#notes-on-token-and-user-permissions) for more information. -->
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--> <!--CONTRIBUTOR COUNT END-->
+![](https://img.shields.io/github/contributors/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}?style=flat-square&label=Contributor%20Count(incl.%20bots)) 
 
 <!-- readme: contributors -start -->
 <!-- readme: contributors -end -->

--- a/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
+++ b/tier4/{{cookiecutter.project_slug}}/COMMUNITY.md
@@ -59,7 +59,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details on the release process.
 
 <!-- TODO: A list of CONTRIBUTORS is generated below using contributors.yml located in the workflows directory. In order to automatically update the COMMUNITY.md, you must enter a secret into your Secrets and Variables under Actions within your repository settings. The name of the secret must be PUSH_TO_PROTECTED_BRANCH and the value must be a Personal Access Token with specific permissions. Please follow [this link](https://github.com/CasperWA/push-protected?tab=readme-ov-file#notes-on-token-and-user-permissions) for more information. -->
 
-Total number of contributors: <!--CONTRIBUTOR COUNT START--> <!--CONTRIBUTOR COUNT END-->
+![](https://img.shields.io/github/contributors/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}?style=flat-square&label=Contributor%20Count(incl.%20bots)) 
 
 <!-- readme: contributors -start -->
 <!-- readme: contributors -end -->


### PR DESCRIPTION
## Workflow: Update contributors.yml with fix and update contributor count in COMMUNITY.md

## Problem

Currently, the contributors workflow on repo-scaffolder itself keeps failing and I'd like to fix this before we make the release. Additionally, contributor count in our COMMUNITY.md templates is not updating. We would like to replace this with a shields badge to display the contributor count.

## Solution

- Now, the workflow creates PRs that update COMMUNITY.md ONLY IF there was been changes detected as done here: https://github.com/DSACMS/repo-scaffolder/pull/363
- Update to use shields badge as inspired by https://github.com/DSACMS/npd/pull/134

## Test Plan
Tests passing, PRs being made