### PR TITLE
feat: allow fileUpdater to handle multiple files #27

### DIFF
--- a/.github/fileUpdater/action.yml
+++ b/.github/fileUpdater/action.yml
@@ -3,8 +3,8 @@ name: 'Update'
 description: 'Update strings'
 
 inputs:
-  find:
-    description: String to replace
+    file:
+    description: 'Comma-separated list of files (e.g. README.md, LICENSE)'
     required: true
   replace:
     description: Replacement string

--- a/.github/fileUpdater/update.sh
+++ b/.github/fileUpdater/update.sh
@@ -1,7 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
-filename=$3
-search=$1
-replace=$2
+FIND=$1
+REPLACE=$2
+FILES_INPUT=$3
 
-sed -i -e "s/$search/$replace/g" $filename
+# Split the comma-separated string into an array
+IFS=',' read -ra FILES <<< "$FILES_INPUT"
+
+for i in "${FILES[@]}"; do
+    # Remove any accidental spaces (like " README.md")
+    FILE=$(echo $i | xargs)
+    
+    echo "Processing file: $FILE"
+    
+    # Check if the file exists before trying to update it
+    if [ -f "$FILE" ]; then
+        # This is where your actual replacement command (likely 'sed') lives
+        # Make sure to use "$FILE" (the variable) here!
+        sed -i "s/$FIND/$REPLACE/g" "$FILE"
+    else
+        echo "Warning: $FILE not found, skipping."
+    fi
+done

--- a/.github/workflows/updateStringInRepos.yml
+++ b/.github/workflows/updateStringInRepos.yml
@@ -20,8 +20,10 @@ on:
                 default: 'y'
                 required: true
             file:
-                description: 'File to replace in'
+                description: 'Comma-separated list of files (e.g. README.md, CONTRIBUTING.md)'
                 default: 'CONTRIBUTING.md'
+                required: true
+
 
 env:
     repo: ""


### PR DESCRIPTION
## github-actions: Update fileUpdater to support multiple files

## Problem

The current fileUpdater implementation only accepts a single file as input. 
Users who need to update strings across multiple files (e.g., README.md and 
CONTRIBUTING.md) have to run the workflow multiple times, which is 
inefficient and creates unnecessary overhead. Fixes #27.

## Solution

I modified the workflow and the underlying bash script to handle a 
comma-separated list of files.

- Updated `updateStringInRepos.yml` and `action.yml` to accept a list of files.
- Modified `update.sh` to use an IFS loop to split the input string.
- Added a check to ensure each file in the list exists before processing.

## Result

The `file` input now accepts multiple file paths separated by commas. The 
action will iterate through the list and apply the string replacement to 
every valid file provided.

## Test Plan

I verified the changes by running the `update.sh` script locally with a 
mock comma-separated string:
1. Created two dummy files: `test1.txt` and `test2.txt`.
2. Ran: `bash .github/fileUpdater/update.sh "old" "new" "test1.txt,test2.txt"`.
3. Confirmed that the string replacement was successful in both files.
4. Verified that the script handles spaces after commas correctly using xargs.
