### PR TITLE
Adding AI Usage Section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,24 @@ will be merged directly into the main branch.
 We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/DSACMS/repo-scaffolder/issues).
 
+## AI Usage
+
+AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
+
+### Recommended uses
+
+- Gaining understanding of the existing code, or solution ideas of the issue
+- Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
+
+Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
+
+### Not recommended uses
+
+- External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
+- Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
+
 ## Policies
 
 ### Open Source Policy

--- a/maturity-model-tiers.md
+++ b/maturity-model-tiers.md
@@ -566,6 +566,16 @@ Each tier outlines specific content that are required or recommended to be inclu
     </tr>
     <tr>
       <!-- <td>CONTRIBUTING.md</td> -->
+      <td>AI Usage</td>
+      <td>$\color{blue}\large{\textsf{R}}$</td>
+      <td>$\color{green}\large{\textsf{M}}$</td>
+      <td>$\color{green}\large{\textsf{M}}$</td>
+      <td>$\color{green}\large{\textsf{M}}$</td>
+      <td>$\color{green}\large{\textsf{M}}$</td>
+      <td>Our stance on how AI usage should be used within software projects. Includes recommended and non recommended uses.</td>
+    </tr>
+    <tr>
+      <!-- <td>CONTRIBUTING.md</td> -->
       <td>Policies</td>
       <td>$\color{blue}\large{\textsf{R}}$</td>
       <td>$\color{green}\large{\textsf{M}}$</td>

--- a/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -98,7 +98,7 @@ AI tools *(LLMs, coding assistants)* are welcome as part of your contribution wo
 
 ### Acceptable uses
 
-- Gaining understanding of the existing code or solution ideas of the issue
+- Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.

--- a/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -92,6 +92,24 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
+## AI Usage
+
+AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
+
+### Acceptable uses
+
+- Gaining understanding of the existing code or solution ideas of the issue
+- Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
+
+Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
+
+### Unacceptable uses
+
+- External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
+- Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
+
 ## Policies
 
 ### Open Source Policy

--- a/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier1/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -96,14 +96,14 @@ docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{
 
 AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
 
-### Acceptable uses
+### Recommended uses
 
 - Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
 
-### Unacceptable uses
+### Not recommended uses
 
 - External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
 - Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -390,6 +390,24 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue]({{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
+# AI Usage
+
+AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
+
+### Acceptable uses
+
+- Gaining understanding of the existing code or solution ideas of the issue
+- Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
+
+Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
+
+### Unacceptable uses
+
+- External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
+- Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
+
 ## Policies
 
 ### Open Source Policy

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -390,18 +390,18 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue]({{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
-# AI Usage
+## AI Usage
 
 AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
 
-### Acceptable uses
+### Recommended uses
 
 - Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
 
-### Unacceptable uses
+### Not recommended uses
 
 - External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
 - Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach

--- a/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier2/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -396,7 +396,7 @@ AI tools *(LLMs, coding assistants)* are welcome as part of your contribution wo
 
 ### Acceptable uses
 
-- Gaining understanding of the existing code or solution ideas of the issue
+- Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -385,6 +385,24 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
+# AI Usage
+
+AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
+
+### Acceptable uses
+
+- Gaining understanding of the existing code or solution ideas of the issue
+- Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
+
+Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
+
+### Unacceptable uses
+
+- External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
+- Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
+
 ## Policies
 
 ### Open Source Policy

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -391,7 +391,7 @@ AI tools *(LLMs, coding assistants)* are welcome as part of your contribution wo
 
 ### Acceptable uses
 
-- Gaining understanding of the existing code or solution ideas of the issue
+- Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.

--- a/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier3/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -385,18 +385,18 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
-# AI Usage
+## AI Usage
 
 AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
 
-### Acceptable uses
+### Recommended uses
 
 - Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
 
-### Unacceptable uses
+### Not recommended uses
 
 - External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
 - Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -409,7 +409,7 @@ AI tools *(LLMs, coding assistants)* are welcome as part of your contribution wo
 
 ### Acceptable uses
 
-- Gaining understanding of the existing code or solution ideas of the issue
+- Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -158,19 +158,38 @@ authorship metadata will be preserved.
 
 ### Table of Contents
 
-- [Versioning](#versioning)
-  <!-- * [Breaking vs. non-breaking changes](#breaking-vs-non-breaking-changes) -->
-  - [Ongoing version support](#ongoing-version-support)
-- [Release Process](#release-process)
-  - [Goals](#goals)
-  - [Schedule](#schedule)
-  - [Communication and Workflow](#communication-and-workflow)
-  <!-- * [Beta Features](#beta-features) -->
-- [Preparing a Release Candidate](#preparing-a-release-candidate)
-  - [Incorporating feedback from review](#incorporating-feedback-from-review)
-- [Making a Release](#making-a-release)
-- [Auto Changelog](#auto-changelog)
-- [Hotfix Releases](#hotfix-releases)
+- [How to Contribute](#how-to-contribute)
+  - [Getting Started](#getting-started)
+    - [Team Specific Guidelines](#team-specific-guidelines)
+    - [Building dependencies](#building-dependencies)
+    - [Building the Project](#building-the-project)
+    - [Workflow and Branching](#workflow-and-branching)
+    - [Testing Conventions](#testing-conventions)
+    - [Coding Style and Linters](#coding-style-and-linters)
+    - [Writing Issues](#writing-issues)
+    - [Writing Pull Requests](#writing-pull-requests)
+  - [Reviewing Pull Requests](#reviewing-pull-requests)
+  - [Shipping Releases](#shipping-releases)
+    - [Table of Contents](#table-of-contents)
+    - [Versioning](#versioning)
+      - [Ongoing version support](#ongoing-version-support)
+    - [Release Process](#release-process)
+      - [Goals](#goals)
+      - [Schedule](#schedule)
+      - [Communication and Workflow](#communication-and-workflow)
+    - [Preparing a Release Candidate](#preparing-a-release-candidate)
+      - [Incorporating feedback from review](#incorporating-feedback-from-review)
+    - [Making a Release](#making-a-release)
+    - [Auto Changelog](#auto-changelog)
+    - [Hotfix Releases](#hotfix-releases)
+  - [Documentation](#documentation)
+- [AI Usage](#ai-usage)
+    - [Acceptable uses](#acceptable-uses)
+    - [Unacceptable uses](#unacceptable-uses)
+  - [Policies](#policies)
+    - [Open Source Policy](#open-source-policy)
+    - [Security and Responsible Disclosure Policy](#security-and-responsible-disclosure-policy)
+  - [Public domain](#public-domain)
 
 ### Versioning
 
@@ -383,6 +402,24 @@ In rare cases, a hotfix for a prior release may be required out-of-phase with th
 We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
+
+# AI Usage
+
+AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
+
+### Acceptable uses
+
+- Gaining understanding of the existing code or solution ideas of the issue
+- Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
+
+Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
+
+### Unacceptable uses
+
+- External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
+- Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach
+- Submitting a PR where the effort you put in, such as writing a prompt, is less than the effort it would take a maintainer to review it. We can already write prompts or run automated tools ourselves and doing that directly is faster and more secure than reviewing a low effort PR.
+- Using AI to increase the breadth of your contributions, such as spreading yourself across several projects at once. You provide more value by engaging deeply with one or two projects than shallowly with many.
 
 ## Policies
 

--- a/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
+++ b/tier4/{{cookiecutter.project_slug}}/CONTRIBUTING.md
@@ -183,9 +183,9 @@ authorship metadata will be preserved.
     - [Auto Changelog](#auto-changelog)
     - [Hotfix Releases](#hotfix-releases)
   - [Documentation](#documentation)
-- [AI Usage](#ai-usage)
-    - [Acceptable uses](#acceptable-uses)
-    - [Unacceptable uses](#unacceptable-uses)
+  - [AI Usage](#ai-usage)
+    - [Recommended uses](#recommended-uses)
+    - [Not recommended uses](#not-recommended-uses)
   - [Policies](#policies)
     - [Open Source Policy](#open-source-policy)
     - [Security and Responsible Disclosure Policy](#security-and-responsible-disclosure-policy)
@@ -403,18 +403,18 @@ We also welcome improvements to the project documentation or to the existing
 docs. Please file an [issue](https://github.com/{{ cookiecutter.project_org }}/{{ cookiecutter.project_repo_name }}/issues).
 -->
 
-# AI Usage
+## AI Usage
 
 AI tools *(LLMs, coding assistants)* are welcome as part of your contribution workflow, but they don't change who's responsible for the code you submit.
 
-### Acceptable uses
+### Recommended uses
 
 - Gaining understanding of the existing code, or solution ideas of the issue
 - Translating or proofreading your comments or PR descriptions while keep the wording as close as possible to what you originally wrote
 
 Whenever you use AI in any of these ways, disclose it explicitly in your PR description.
 
-### Unacceptable uses
+### Not recommended uses
 
 - External AI tooling *(bots, agents)* directly interacting with the project, including creating issues, opening PRs, or commenting on GitHub
 - Submitting AI generated code you can't explain line by line to a developer, or using AI output without fully understanding it or verifying it's the correct approach


### PR DESCRIPTION
## Adding AI Usage Section to CONTRIBUTING.md

## Problem
We do not have any guidance regarding AI usage within our documentation leaving users confused as to what our stance is on the subject.

## Solution
Add a section specifically talking about what is and what is not allowed regarding AI usage for our projects.

## Result
An in depth section for AI usage within CONTRIBUTING.md guiding users on our policies
