### PR TITLE
 Add GitHub repository topic prompts and automatic topic assignment`

### DIFF
--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -6,12 +6,10 @@
     "project_description": "This is the project description, could match github.com repo description.",
     "project_visibility": ["public", "internal", "private"],
     "create_repo": [true, false],
-    "maturity_org_name": "cmsoss",
     "extra_repo_topics": "",
     "add_team": [true, false],
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
-      "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier0).",
       "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
       "add_team": "Would you like to add project team members to COMMUNITY.md?"
     },

--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -12,7 +12,7 @@
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier0).",
-      "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
+      "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
       "add_team": "Would you like to add project team members to COMMUNITY.md?"
     },
     "_copy_without_render": [".github/codejson"]

--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -6,11 +6,13 @@
     "project_description": "This is the project description, could match github.com repo description.",
     "project_visibility": ["public", "internal", "private"],
     "create_repo": [true, false],
-    "receive_updates": [true, false],
+    "maturity_org_name": "cmsoss",
+    "extra_repo_topics": "",
     "add_team": [true, false],
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
-      "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+      "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier0).",
+      "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
       "add_team": "Would you like to add project team members to COMMUNITY.md?"
     },
     "_copy_without_render": [".github/codejson"]

--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -1,14 +1,17 @@
 import subprocess
 import shutil
 import os
+import re
 
 REPO_NAME = '{{ cookiecutter.project_repo_name }}'
 ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
+EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
+MATURITY_TIER = "tier0"
 
 def createGithubRepo():
     gh_cli_command = [
@@ -22,12 +25,38 @@ def createGithubRepo():
     subprocess.call(gh_cli_command)
     subprocess.call(["git", "push", "--set-upstream", "origin", "main"])
 
-def addTopic():
+def normalize_topic(topic):
+    topic = topic.strip().lower()
+    topic = re.sub(r"[\s_]+", "-", topic)
+    topic = re.sub(r"[^a-z0-9-]", "", topic)
+    topic = re.sub(r"-+", "-", topic)
+
+    return topic.strip("-")
+
+
+def get_repo_topics():
+    maturity_topic = normalize_topic(
+        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    )
+
+    topics = [maturity_topic]
+
+    for topic in EXTRA_REPO_TOPICS.split(","):
+        normalized_topic = normalize_topic(topic)
+
+        if normalized_topic and normalized_topic not in topics:
+            topics.append(normalized_topic)
+
+    return topics
+
+def addTopics():
+    topics = get_repo_topics()
     gh_cli_command = [
         "gh", "repo", "edit",
         f"{ORG_NAME}/{REPO_NAME}",
-        "--add-topic=dsacms-tier0",
     ]
+    for topic in topics:
+        gh_cli_command.append(f"--add-topic={topic}")
     subprocess.call(gh_cli_command)
 
 def addTeam():
@@ -96,9 +125,8 @@ def main():
     
     if CREATE_REPO == "True":
         createGithubRepo()
+        addTopics()
 
-    if RECEIVE_UPDATES == "True":
-        addTopic()
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")

--- a/tier0/hooks/post_gen_project.py
+++ b/tier0/hooks/post_gen_project.py
@@ -8,7 +8,6 @@ ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
 MATURITY_TIER = "tier0"
@@ -35,11 +34,11 @@ def normalize_topic(topic):
 
 
 def get_repo_topics():
-    maturity_topic = normalize_topic(
-        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    org_topic = normalize_topic(
+        f"{ORG_NAME}-{MATURITY_TIER}"
     )
 
-    topics = [maturity_topic]
+    topics = [org_topic]
 
     for topic in EXTRA_REPO_TOPICS.split(","):
         normalized_topic = normalize_topic(topic)

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -12,7 +12,7 @@
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier1).",
-    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -6,12 +6,10 @@
   "project_description": "This is the project description, could match github.com repo description.",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "maturity_org_name": "cmsoss",
   "extra_repo_topics": "",
   "add_team": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
-    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier1).",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -6,11 +6,13 @@
   "project_description": "This is the project description, could match github.com repo description.",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "receive_updates": [true, false],
+  "maturity_org_name": "cmsoss",
+  "extra_repo_topics": "",
   "add_team": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
-    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier1).",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -1,14 +1,17 @@
 import subprocess
 import shutil
 import os
+import re
 
 REPO_NAME = '{{ cookiecutter.project_repo_name }}'
 ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
+EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
+MATURITY_TIER = "tier0"
 
 def createGithubRepo():
     gh_cli_command = [
@@ -22,12 +25,38 @@ def createGithubRepo():
     subprocess.call(gh_cli_command)
     subprocess.call(["git", "push", "--set-upstream", "origin", "main"])
 
-def addTopic():
+def normalize_topic(topic):
+    topic = topic.strip().lower()
+    topic = re.sub(r"[\s_]+", "-", topic)
+    topic = re.sub(r"[^a-z0-9-]", "", topic)
+    topic = re.sub(r"-+", "-", topic)
+
+    return topic.strip("-")
+
+
+def get_repo_topics():
+    maturity_topic = normalize_topic(
+        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    )
+
+    topics = [maturity_topic]
+
+    for topic in EXTRA_REPO_TOPICS.split(","):
+        normalized_topic = normalize_topic(topic)
+
+        if normalized_topic and normalized_topic not in topics:
+            topics.append(normalized_topic)
+
+    return topics
+
+def addTopics():
+    topics = get_repo_topics()
     gh_cli_command = [
         "gh", "repo", "edit",
         f"{ORG_NAME}/{REPO_NAME}",
-        "--add-topic=dsacms-tier1",
     ]
+    for topic in topics:
+        gh_cli_command.append(f"--add-topic={topic}")
     subprocess.call(gh_cli_command)
 
 def addTeam():
@@ -96,9 +125,8 @@ def main():
     
     if CREATE_REPO == "True":
         createGithubRepo()
-
-    if RECEIVE_UPDATES == "True":
-        addTopic()
+        addTopics()
+        
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -8,7 +8,6 @@ ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
 MATURITY_TIER = "tier1"
@@ -35,11 +34,11 @@ def normalize_topic(topic):
 
 
 def get_repo_topics():
-    maturity_topic = normalize_topic(
-        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    org_topic = normalize_topic(
+        f"{ORG_NAME}-{MATURITY_TIER}"
     )
 
-    topics = [maturity_topic]
+    topics = [org_topic]
 
     for topic in EXTRA_REPO_TOPICS.split(","):
         normalized_topic = normalize_topic(topic)

--- a/tier1/hooks/post_gen_project.py
+++ b/tier1/hooks/post_gen_project.py
@@ -11,7 +11,7 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
-MATURITY_TIER = "tier0"
+MATURITY_TIER = "tier1"
 
 def createGithubRepo():
     gh_cli_command = [

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -7,12 +7,14 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "receive_updates": [true, false],
+  "maturity_org_name": "cmsoss",
+  "extra_repo_topics": "",
   "add_team": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier2).",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -14,7 +14,7 @@
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
     "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier2).",
-    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },
   "_copy_without_render": [".github/codejson"]

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -7,13 +7,11 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "maturity_org_name": "cmsoss",
   "extra_repo_topics": "",
   "add_team": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier2).",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?"
   },

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -8,7 +8,6 @@ ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
 MATURITY_TIER = "tier2"
@@ -35,11 +34,11 @@ def normalize_topic(topic):
 
 
 def get_repo_topics():
-    maturity_topic = normalize_topic(
-        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    org_topic = normalize_topic(
+        f"{ORG_NAME}-{MATURITY_TIER}"
     )
 
-    topics = [maturity_topic]
+    topics = [org_topic]
 
     for topic in EXTRA_REPO_TOPICS.split(","):
         normalized_topic = normalize_topic(topic)

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -11,7 +11,7 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
-MATURITY_TIER = "tier0"
+MATURITY_TIER = "tier2"
 
 def createGithubRepo():
     gh_cli_command = [

--- a/tier2/hooks/post_gen_project.py
+++ b/tier2/hooks/post_gen_project.py
@@ -1,14 +1,17 @@
 import subprocess
 import shutil
 import os
+import re
 
 REPO_NAME = '{{ cookiecutter.project_repo_name }}'
 ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
+EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
+MATURITY_TIER = "tier0"
 
 def createGithubRepo():
     gh_cli_command = [
@@ -22,12 +25,38 @@ def createGithubRepo():
     subprocess.call(gh_cli_command)
     subprocess.call(["git", "push", "--set-upstream", "origin", "main"])
 
-def addTopic():
+def normalize_topic(topic):
+    topic = topic.strip().lower()
+    topic = re.sub(r"[\s_]+", "-", topic)
+    topic = re.sub(r"[^a-z0-9-]", "", topic)
+    topic = re.sub(r"-+", "-", topic)
+
+    return topic.strip("-")
+
+
+def get_repo_topics():
+    maturity_topic = normalize_topic(
+        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    )
+
+    topics = [maturity_topic]
+
+    for topic in EXTRA_REPO_TOPICS.split(","):
+        normalized_topic = normalize_topic(topic)
+
+        if normalized_topic and normalized_topic not in topics:
+            topics.append(normalized_topic)
+
+    return topics
+
+def addTopics():
+    topics = get_repo_topics()
     gh_cli_command = [
         "gh", "repo", "edit",
         f"{ORG_NAME}/{REPO_NAME}",
-        "--add-topic=dsacms-tier2",
     ]
+    for topic in topics:
+        gh_cli_command.append(f"--add-topic={topic}")
     subprocess.call(gh_cli_command)
 
 def addTeam():
@@ -96,12 +125,11 @@ def main():
 
     if CREATE_REPO == "True":
         createGithubRepo()
-
-    if RECEIVE_UPDATES == "True":
-        addTopic()
+        addTopics()
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")
+    
         
 if __name__ == "__main__":
     main()

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -7,13 +7,15 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "receive_updates": [true, false],
+  "maturity_org_name": "cmsoss",
+  "extra_repo_topics": "",
   "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier3).",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -7,14 +7,12 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "maturity_org_name": "cmsoss",
   "extra_repo_topics": "",
   "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier3).",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -15,7 +15,7 @@
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
     "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier3).",
-    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -8,7 +8,6 @@ ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
 MATURITY_TIER = "tier3"
@@ -36,11 +35,11 @@ def normalize_topic(topic):
 
 
 def get_repo_topics():
-    maturity_topic = normalize_topic(
-        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    org_topic = normalize_topic(
+        f"{ORG_NAME}-{MATURITY_TIER}"
     )
 
-    topics = [maturity_topic]
+    topics = [org_topic]
 
     for topic in EXTRA_REPO_TOPICS.split(","):
         normalized_topic = normalize_topic(topic)

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -1,14 +1,17 @@
 import subprocess
 import shutil
 import os
+import re
 
 REPO_NAME = '{{ cookiecutter.project_repo_name }}'
 ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
+EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
+MATURITY_TIER = "tier0"
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
@@ -23,12 +26,38 @@ def createGithubRepo():
     subprocess.call(gh_cli_command)
     subprocess.call(["git", "push", "--set-upstream", "origin", "main"])
 
-def addTopic():
+def normalize_topic(topic):
+    topic = topic.strip().lower()
+    topic = re.sub(r"[\s_]+", "-", topic)
+    topic = re.sub(r"[^a-z0-9-]", "", topic)
+    topic = re.sub(r"-+", "-", topic)
+
+    return topic.strip("-")
+
+
+def get_repo_topics():
+    maturity_topic = normalize_topic(
+        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    )
+
+    topics = [maturity_topic]
+
+    for topic in EXTRA_REPO_TOPICS.split(","):
+        normalized_topic = normalize_topic(topic)
+
+        if normalized_topic and normalized_topic not in topics:
+            topics.append(normalized_topic)
+
+    return topics
+
+def addTopics():
+    topics = get_repo_topics()
     gh_cli_command = [
         "gh", "repo", "edit",
         f"{ORG_NAME}/{REPO_NAME}",
-        "--add-topic=dsacms-tier3",
     ]
+    for topic in topics:
+        gh_cli_command.append(f"--add-topic={topic}")
     subprocess.call(gh_cli_command)
 
 # Helper function for addMaintainer() to get user input of usernames for Maintainer, Approver, and Reviewer
@@ -135,9 +164,7 @@ def main():
 
     if CREATE_REPO == "True":
         createGithubRepo()
-
-    if RECEIVE_UPDATES == "True":
-        addTopic()
+        addTopics()
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")

--- a/tier3/hooks/post_gen_project.py
+++ b/tier3/hooks/post_gen_project.py
@@ -11,7 +11,7 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
-MATURITY_TIER = "tier0"
+MATURITY_TIER = "tier3"
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -7,14 +7,12 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "maturity_org_name": "cmsoss",
   "extra_repo_topics": "",
   "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier4).",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -15,7 +15,7 @@
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
     "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier4).",
-    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -7,13 +7,15 @@
   "code_owners": "",
   "project_visibility": ["public", "internal", "private"],
   "create_repo": [true, false],
-  "receive_updates": [true, false],
+  "maturity_org_name": "cmsoss",
+  "extra_repo_topics": "",
   "add_team": [true, false],
   "add_maintainer": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
-    "receive_updates": "Would you like to receive updates from the DSACMS team via pull requests?",
+    "maturity_org_name": "Organization name for maturity model topic name (press Enter to use the default: cmsoss-tier4).",
+    "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
     "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
   },

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -8,7 +8,6 @@ ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
 MATURITY_TIER = "tier4"
@@ -36,11 +35,11 @@ def normalize_topic(topic):
 
 
 def get_repo_topics():
-    maturity_topic = normalize_topic(
-        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    org_topic = normalize_topic(
+        f"{ORG_NAME}-{MATURITY_TIER}"
     )
 
-    topics = [maturity_topic]
+    topics = [org_topic]
 
     for topic in EXTRA_REPO_TOPICS.split(","):
         normalized_topic = normalize_topic(topic)
@@ -168,7 +167,6 @@ def main():
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")
-    print(f"here are the additional repo topics: {get_repo_topics()}")
     
 if __name__ == "__main__":
     main()

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -1,14 +1,17 @@
 import subprocess
 import shutil
 import os
+import re
 
 REPO_NAME = '{{ cookiecutter.project_repo_name }}'
 ORG_NAME = '{{ cookiecutter.project_org }}'
 VISIBILITY = '{{cookiecutter.project_visibility}}'
 DESCRIPTION = '{{cookiecutter.project_description}}'
 CREATE_REPO = '{{cookiecutter.create_repo}}'
-RECEIVE_UPDATES = '{{cookiecutter.receive_updates}}'
+MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
+EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
+MATURITY_TIER = "tier0"
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():
@@ -23,12 +26,38 @@ def createGithubRepo():
     subprocess.call(gh_cli_command)
     subprocess.call(["git", "push", "--set-upstream", "origin", "main"])
 
-def addTopic():
+def normalize_topic(topic):
+    topic = topic.strip().lower()
+    topic = re.sub(r"[\s_]+", "-", topic)
+    topic = re.sub(r"[^a-z0-9-]", "", topic)
+    topic = re.sub(r"-+", "-", topic)
+
+    return topic.strip("-")
+
+
+def get_repo_topics():
+    maturity_topic = normalize_topic(
+        f"{MATURITY_ORG_NAME}-{MATURITY_TIER}"
+    )
+
+    topics = [maturity_topic]
+
+    for topic in EXTRA_REPO_TOPICS.split(","):
+        normalized_topic = normalize_topic(topic)
+
+        if normalized_topic and normalized_topic not in topics:
+            topics.append(normalized_topic)
+
+    return topics
+
+def addTopics():
+    topics = get_repo_topics()
     gh_cli_command = [
         "gh", "repo", "edit",
         f"{ORG_NAME}/{REPO_NAME}",
-        "--add-topic=dsacms-tier4",
     ]
+    for topic in topics:
+        gh_cli_command.append(f"--add-topic={topic}")
     subprocess.call(gh_cli_command)
 
 # Helper function for addMaintainer() to get user input of usernames for Maintainer, Approver, and Reviewer
@@ -135,12 +164,11 @@ def main():
 
     if CREATE_REPO == "True":
         createGithubRepo()
-
-    if RECEIVE_UPDATES == "True":
-        addTopic()
+        addTopics()
     
     print(f"\n****************************************")
     print(f"\n✅ {REPO_NAME} has successfully been created!\n")
+    print(f"here are the additional repo topics: {get_repo_topics()}")
     
 if __name__ == "__main__":
     main()

--- a/tier4/hooks/post_gen_project.py
+++ b/tier4/hooks/post_gen_project.py
@@ -11,7 +11,7 @@ CREATE_REPO = '{{cookiecutter.create_repo}}'
 MATURITY_ORG_NAME = '{{cookiecutter.maturity_org_name}}'
 EXTRA_REPO_TOPICS = '{{cookiecutter.extra_repo_topics}}'
 ADD_TEAM = '{{cookiecutter.add_team}}'
-MATURITY_TIER = "tier0"
+MATURITY_TIER = "tier4"
 ADD_MAINTAINER = '{{cookiecutter.add_maintainer}}'
 
 def createGithubRepo():


### PR DESCRIPTION
## Problem

The repository scaffolder did not provide a way to assign extra GitHub repository topics during project creation nor have a custom name for the required maturity model names. As a result, required maturity model topics and additional repository topics had to be added manually after a repository was created. Additionally, the existing `receive_updates` prompt was no longer needed for this workflow. (The receive_updates would simply add a regular tier topic, which this implementation does as well)

## Solution

* Added Cookiecutter prompts to collect the maturity organization name and optional GitHub repository topics.
* Added `normalize_topic()` and `get_repo_topics()` to normalize, validate, and assemble the list of repository topics.
* Updated `addTopics()` to automatically apply the generated topics to the newly created GitHub repository.
* Updated `main()` to invoke `addTopics()` after repository creation.
* Removed the unused `receive_updates` prompt and related logic.
* Applied the changes across all five Cookiecutter templates (Tier 0 through Tier 4), with each template automatically assigning its corresponding maturity tier.

## Result

Repositories created with the scaffolder are automatically assigned the appropriate maturity model topic along with any additional GitHub topics provided during project generation, eliminating the need to manually configure repository topics after creation.

## Test Plan

* Generated repositories locally using each of the Tier 0 through Tier 4 templates.
* Verified the new Cookiecutter prompts appeared as expected.
* Confirmed repository topics were normalized and generated correctly from the user input.
* Verified the correct maturity tier topic was assigned for each template.
* Confirmed duplicate and empty topics were handled correctly.