### PR TITLE
docs(templates): add PRA, Plain Language and Section 508 guidance to the README templates

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,14 @@ def context(template_tier):
         "project_visibility": "private",
         "create_repo": False,
         "receive_updates": False,
-        "add_team": False
+        "add_team": False,
+        "accessibility": False
     }
     if template_tier == 3 or template_tier == 4:
         context.update({
             "code_owners": "",
-            "add_maintainer": False
+            "add_maintainer": False,
+            "pra": False
         })
     return context
 

--- a/tier0/cookiecutter.json
+++ b/tier0/cookiecutter.json
@@ -8,10 +8,12 @@
     "create_repo": [true, false],
     "extra_repo_topics": "",
     "add_team": [true, false],
+    "accessibility": [true, false],
     "__prompts__": {
       "create_repo": "Would you like to create a repo on github.com?",
       "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
-      "add_team": "Would you like to add project team members to COMMUNITY.md?"
+      "add_team": "Would you like to add project team members to COMMUNITY.md?",
+      "accessibility": "Does your project adhere to Section 508 accessibility standards?"
     },
     "_copy_without_render": [".github/codejson"]
 }

--- a/tier0/{{cookiecutter.project_slug}}/README.md
+++ b/tier0/{{cookiecutter.project_slug}}/README.md
@@ -91,26 +91,12 @@ In the spirit of [Executive Order 14028 - Improving the Nation's Cyber Security]
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
-### Paperwork Reduction Act
-
-If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
-may apply. It is triggered by collecting standardized information from ten or more members of the
-public within a twelve month period, which includes forms, surveys, and some kinds of user research,
-and it requires OMB clearance before the collection begins rather than after.
-
-See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
-works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
-
+{%- if cookiecutter.accessibility -%}
 ### Accessibility
 
-This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
-requires that information and communication technology developed, procured, maintained, or used by
-federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
-[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which requires that information and communication technology developed, procured, maintained, or used by federal agencies be accessible to people with disabilities.
 
-Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
-screen reader, as part of normal development rather than as a release gate.
+{% endif %}
 
 ## Public domain
 

--- a/tier0/{{cookiecutter.project_slug}}/README.md
+++ b/tier0/{{cookiecutter.project_slug}}/README.md
@@ -91,6 +91,36 @@ In the spirit of [Executive Order 14028 - Improving the Nation's Cyber Security]
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+### Paperwork Reduction Act
+
+If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
+may apply. It is triggered by collecting standardized information from ten or more members of the
+public within a twelve month period, which includes forms, surveys, and some kinds of user research,
+and it requires OMB clearance before the collection begins rather than after.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
+works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+### Plain Language
+
+Public-facing content in this project follows the [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/),
+as required by the [Plain Writing Act of 2010](https://www.plainlanguage.gov/law/). The test is
+whether a reader can find what they need, understand it the first time they read it, and use it.
+
+This applies to documentation as much as to interface text. A README is often the first thing a
+member of the public reads about a government project.
+
+### Accessibility
+
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
+requires that information and communication technology developed, procured, maintained, or used by
+federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
+[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
+[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+
+Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
+screen reader, as part of normal development rather than as a release gate.
+
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).

--- a/tier1/cookiecutter.json
+++ b/tier1/cookiecutter.json
@@ -8,10 +8,12 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
+  "accessibility": [true, false],
   "__prompts__": {
     "create_repo": "Would you like to create a repo on github.com?",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
-    "add_team": "Would you like to add project team members to COMMUNITY.md?"
+    "add_team": "Would you like to add project team members to COMMUNITY.md?",
+    "accessibility": "Does your project adhere to Section 508 accessibility standards?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -128,6 +128,36 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+### Paperwork Reduction Act
+
+If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
+may apply. It is triggered by collecting standardized information from ten or more members of the
+public within a twelve month period, which includes forms, surveys, and some kinds of user research,
+and it requires OMB clearance before the collection begins rather than after.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
+works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+### Plain Language
+
+Public-facing content in this project follows the [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/),
+as required by the [Plain Writing Act of 2010](https://www.plainlanguage.gov/law/). The test is
+whether a reader can find what they need, understand it the first time they read it, and use it.
+
+This applies to documentation as much as to interface text. A README is often the first thing a
+member of the public reads about a government project.
+
+### Accessibility
+
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
+requires that information and communication technology developed, procured, maintained, or used by
+federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
+[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
+[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+
+Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
+screen reader, as part of normal development rather than as a release gate.
+
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).

--- a/tier1/{{cookiecutter.project_slug}}/README.md
+++ b/tier1/{{cookiecutter.project_slug}}/README.md
@@ -128,26 +128,12 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
-### Paperwork Reduction Act
-
-If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
-may apply. It is triggered by collecting standardized information from ten or more members of the
-public within a twelve month period, which includes forms, surveys, and some kinds of user research,
-and it requires OMB clearance before the collection begins rather than after.
-
-See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
-works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
-
+{%- if cookiecutter.accessibility -%}
 ### Accessibility
 
-This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
-requires that information and communication technology developed, procured, maintained, or used by
-federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
-[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which requires that information and communication technology developed, procured, maintained, or used by federal agencies be accessible to people with disabilities.
 
-Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
-screen reader, as part of normal development rather than as a release gate.
+{% endif %}
 
 ## Public domain
 

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -22,9 +22,9 @@ This is a review process to approve CMS-developed software to be released open s
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
-[Review Policies](#review-policies)
-
 [Review Project Metadata](#review-project-metadata)
+
+[Review Policies](#review-policies)
 
 [Review Repository Details](#review-repository-details)
 
@@ -329,36 +329,6 @@ Please refer to the style guides below for additional tips and guidance:
 
 _Insert Review Here_
 
-### Review Policies
-
-Before public release, review the policies below to check if they apply to your repository:
-
-#### Paperwork Reduction Act
-
-Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?
-
-If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after. 
-
-Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
-
-See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
-
-#### 508 Accessibility
-
-Does your project have 508 requirements?
-
-If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA. 
-
-Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
-
-Use automated accessibility checkers and 508 tools to identify issues early. Test with both keyboard navigation and screen readers as part of regular development rather than as a release gate. Automated tools catch only a portion of accessibility defects, so a combination of automated and manual testing remains essential. 
-
-See [ospo-guide](https://dsacms.github.io/ospo-guide/growing/508-training/) for Section 508 resources.
-
-#### Results
-
-_Insert Review Here_
-
 ### Review Project Metadata
 
 As part of the [SHARE IT Act](https://www.congress.gov/bill/118th-congress/house-bill/9566/text), [Federal Source Code Policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2016/m_16_21.pdf), and the agency’s software inventory tracking initiatives, each repository must contain a [code.json file](https://github.com/DSACMS/gov-codejson/blob/main/docs/metadata.md), storing metadata on your project.
@@ -393,6 +363,36 @@ cookiecutter . –directory=codejson
 4. A code.json file will be generated with your responses.
 
 As you continue development in this repository, it is important to keep this file up-to-date. Our [automated-codejson-generator](https://github.com/DSACMS/automated-codejson-generator) can assist with updating this file.
+
+#### Results
+
+_Insert Review Here_
+
+### Review Policies
+
+Before public release, review the policies below to check if they apply to your repository:
+
+#### Paperwork Reduction Act
+
+Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?
+
+If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+#### 508 Accessibility
+
+Does your project have 508 requirements?
+
+If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+Use automated accessibility checkers and 508 tools to identify issues early. Test with both keyboard navigation and screen readers as part of regular development rather than as a release gate. Automated tools catch only a portion of accessibility defects, so a combination of automated and manual testing remains essential. 
+
+See [ospo-guide](https://dsacms.github.io/ospo-guide/growing/508-training/) for Section 508 resources.
 
 #### Results
 

--- a/tier2/checklist.md
+++ b/tier2/checklist.md
@@ -22,6 +22,8 @@ This is a review process to approve CMS-developed software to be released open s
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Policies](#review-policies)
+
 [Review Project Metadata](#review-project-metadata)
 
 [Review Repository Details](#review-repository-details)
@@ -327,27 +329,35 @@ Please refer to the style guides below for additional tips and guidance:
 
 _Insert Review Here_
 
-#### Review Policies
+### Review Policies
 
-Before public release, review the policies below to check if they apply to your repository. If so, be sure to uncomment and add the following policies to the README under the "Policies" section:
+Before public release, review the policies below to check if they apply to your repository:
 
-##### Paperwork Reduction Act
+#### Paperwork Reduction Act
 
 Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?
 
-If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after.
+If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
 
 See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
 
-##### 508 Accessibility
+#### 508 Accessibility
 
 Does your project have 508 requirements?
 
-If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
 
 Use automated accessibility checkers and 508 tools to identify issues early. Test with both keyboard navigation and screen readers as part of regular development rather than as a release gate. Automated tools catch only a portion of accessibility defects, so a combination of automated and manual testing remains essential. 
 
 See [ospo-guide](https://dsacms.github.io/ospo-guide/growing/508-training/) for Section 508 resources.
+
+#### Results
+
+_Insert Review Here_
 
 ### Review Project Metadata
 

--- a/tier2/cookiecutter.json
+++ b/tier2/cookiecutter.json
@@ -9,8 +9,8 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
-  "pra": [true, false],
   "accessibility": [true, false],
+  "pra": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",

--- a/tier2/{{cookiecutter.project_slug}}/README.md
+++ b/tier2/{{cookiecutter.project_slug}}/README.md
@@ -145,6 +145,36 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+### Paperwork Reduction Act
+
+If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
+may apply. It is triggered by collecting standardized information from ten or more members of the
+public within a twelve month period, which includes forms, surveys, and some kinds of user research,
+and it requires OMB clearance before the collection begins rather than after.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
+works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+### Plain Language
+
+Public-facing content in this project follows the [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/),
+as required by the [Plain Writing Act of 2010](https://www.plainlanguage.gov/law/). The test is
+whether a reader can find what they need, understand it the first time they read it, and use it.
+
+This applies to documentation as much as to interface text. A README is often the first thing a
+member of the public reads about a government project.
+
+### Accessibility
+
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
+requires that information and communication technology developed, procured, maintained, or used by
+federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
+[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
+[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+
+Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
+screen reader, as part of normal development rather than as a release gate.
+
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).

--- a/tier2/{{cookiecutter.project_slug}}/README.md
+++ b/tier2/{{cookiecutter.project_slug}}/README.md
@@ -149,14 +149,15 @@ For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom
 ### Paperwork Reduction Act
 
 The [Paperwork Reduction Act](https://pra.digital.gov/) applies to this project since it collects information from the public.
+
 {% endif %}
 
 {%- if cookiecutter.accessibility -%}
 ### Accessibility
 
 This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which requires that information and communication technology developed, procured, maintained, or used by federal agencies be accessible to people with disabilities.
-{% endif %}
 
+{% endif %}
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).

--- a/tier3/checklist.md
+++ b/tier3/checklist.md
@@ -27,6 +27,8 @@ If you would like your repository to be released, please complete the following 
 
 [Review Project Metadata](#review-project-metadata)
 
+[Review Policies](#review-policies)
+
 [Review Repository Details](#review-repository-details)
 
 [Additional Notes & Questions](#additional-notes--questions)
@@ -402,6 +404,36 @@ cookiecutter . –directory=codejson
 4. A code.json file will be generated with your responses.
 
 As you continue development in this repository, it is important to keep this file up-to-date. Our [automated-codejson-generator](https://github.com/DSACMS/automated-codejson-generator) can assist with updating this file.
+
+#### Results
+
+_Insert Review Here_
+
+### Review Policies
+
+Before public release, review the policies below to check if they apply to your repository:
+
+#### Paperwork Reduction Act
+
+Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?
+
+If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+#### 508 Accessibility
+
+Does your project have 508 requirements?
+
+If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+Use automated accessibility checkers and 508 tools to identify issues early. Test with both keyboard navigation and screen readers as part of regular development rather than as a release gate. Automated tools catch only a portion of accessibility defects, so a combination of automated and manual testing remains essential. 
+
+See [ospo-guide](https://dsacms.github.io/ospo-guide/growing/508-training/) for Section 508 resources.
 
 #### Results
 

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -9,13 +9,15 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
-  "add_maintainer": [true, false],
+  "pra": [true, false],
+  "accessibility": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
-    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
+    "accessibility": "Does your project adhere to Section 508 accessibility standards?",
+    "pra": "Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -9,6 +9,7 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
+  "add_maintainer": [true, false],
   "accessibility": [true, false],
   "pra": [true, false],
   "__prompts__": {
@@ -16,6 +17,7 @@
     "create_repo": "Would you like to create a repo on github.com?",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
+    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?",
     "accessibility": "Does your project adhere to Section 508 accessibility standards?",
     "pra": "Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?"
   },

--- a/tier3/cookiecutter.json
+++ b/tier3/cookiecutter.json
@@ -9,8 +9,8 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
-  "pra": [true, false],
   "accessibility": [true, false],
+  "pra": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -121,6 +121,36 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+### Paperwork Reduction Act
+
+If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
+may apply. It is triggered by collecting standardized information from ten or more members of the
+public within a twelve month period, which includes forms, surveys, and some kinds of user research,
+and it requires OMB clearance before the collection begins rather than after.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
+works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+### Plain Language
+
+Public-facing content in this project follows the [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/),
+as required by the [Plain Writing Act of 2010](https://www.plainlanguage.gov/law/). The test is
+whether a reader can find what they need, understand it the first time they read it, and use it.
+
+This applies to documentation as much as to interface text. A README is often the first thing a
+member of the public reads about a government project.
+
+### Accessibility
+
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
+requires that information and communication technology developed, procured, maintained, or used by
+federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
+[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
+[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+
+Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
+screen reader, as part of normal development rather than as a release gate.
+
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).

--- a/tier3/{{cookiecutter.project_slug}}/README.md
+++ b/tier3/{{cookiecutter.project_slug}}/README.md
@@ -121,26 +121,19 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+{%- if cookiecutter.pra -%}
 ### Paperwork Reduction Act
 
-If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
-may apply. It is triggered by collecting standardized information from ten or more members of the
-public within a twelve month period, which includes forms, surveys, and some kinds of user research,
-and it requires OMB clearance before the collection begins rather than after.
+The [Paperwork Reduction Act](https://pra.digital.gov/) applies to this project since it collects information from the public.
 
-See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
-works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+{% endif %}
 
+{%- if cookiecutter.accessibility -%}
 ### Accessibility
 
-This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
-requires that information and communication technology developed, procured, maintained, or used by
-federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
-[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which requires that information and communication technology developed, procured, maintained, or used by federal agencies be accessible to people with disabilities.
 
-Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
-screen reader, as part of normal development rather than as a release gate.
+{% endif %}
 
 ## Public domain
 

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -25,9 +25,9 @@ If you would like your repository to be released, please complete the following 
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
-[Review Policies](#review-policies)
-
 [Review Project Metadata](#review-project-metadata)
+
+[Review Policies](#review-policies)
 
 [Review Repository Details](#review-repository-details)
 

--- a/tier4/checklist.md
+++ b/tier4/checklist.md
@@ -25,6 +25,8 @@ If you would like your repository to be released, please complete the following 
 
 [Review Repository Hygiene](#review-repository-hygiene)
 
+[Review Policies](#review-policies)
+
 [Review Project Metadata](#review-project-metadata)
 
 [Review Repository Details](#review-repository-details)
@@ -417,6 +419,36 @@ cookiecutter . –directory=codejson
 4. A code.json file will be generated with your responses.
 
 As you continue development in this repository, it is important to keep this file up-to-date. Our [automated-codejson-generator](https://github.com/DSACMS/automated-codejson-generator) can assist with updating this file.
+
+#### Results
+
+_Insert Review Here_
+
+### Review Policies
+
+Before public release, review the policies below to check if they apply to your repository:
+
+#### Paperwork Reduction Act
+
+Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?
+
+If yes, then the Paperwork Reduction Act applies to your project. It is triggered by collecting standardized information from ten or more members of the public within a twelve month period, and it requires OMB clearance before the collection begins rather than after. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+#### 508 Accessibility
+
+Does your project have 508 requirements?
+
+If yes, ensure they are met before release. The Revised 508 Standards incorporate [WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target [WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA. 
+
+Be sure to uncomment and add the [Paperwork Reduction Act text](https://github.com/DSACMS/repo-scaffolder/blob/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/README.md#paperwork-reduction-act) to the README.md under the "Policies" section.
+
+Use automated accessibility checkers and 508 tools to identify issues early. Test with both keyboard navigation and screen readers as part of regular development rather than as a release gate. Automated tools catch only a portion of accessibility defects, so a combination of automated and manual testing remains essential. 
+
+See [ospo-guide](https://dsacms.github.io/ospo-guide/growing/508-training/) for Section 508 resources.
 
 #### Results
 

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -9,13 +9,15 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
-  "add_maintainer": [true, false],
+  "pra": [true, false],
+  "accessibility": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
-    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?"
+    "accessibility": "Does your project adhere to Section 508 accessibility standards?",
+    "pra": "Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?"
   },
   "_copy_without_render": [".github/codejson"]
 }

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -9,6 +9,7 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
+  "add_maintainer": [true, false],
   "accessibility": [true, false],
   "pra": [true, false],
   "__prompts__": {
@@ -16,6 +17,7 @@
     "create_repo": "Would you like to create a repo on github.com?",
     "extra_repo_topics": "Enter additional GitHub topics (comma-separated, optional). Example: content-management,dashboard,regulations-and-directives,CodingItForward,Medicare,Medicaid,CMCS,CCSQ",
     "add_team": "Would you like to add project team members to COMMUNITY.md?",
+    "add_maintainer": "Would you like to add maintainers, approvers, and/or reviewers to COMMUNITY.md?",
     "accessibility": "Does your project adhere to Section 508 accessibility standards?",
     "pra": "Does your project collect standardized information from 10 or more members of the public within a twelve month period, which includes forms, surveys, and some kinds of user research?"
   },

--- a/tier4/cookiecutter.json
+++ b/tier4/cookiecutter.json
@@ -9,8 +9,8 @@
   "create_repo": [true, false],
   "extra_repo_topics": "",
   "add_team": [true, false],
-  "pra": [true, false],
   "accessibility": [true, false],
+  "pra": [true, false],
   "__prompts__": {
     "code_owners": "Would you like to add a CODEOWNERS.md to get notified on repository updates? If so, please provide the usernames separated by commas.",
     "create_repo": "Would you like to create a repo on github.com?",

--- a/tier4/{{cookiecutter.project_slug}}/README.md
+++ b/tier4/{{cookiecutter.project_slug}}/README.md
@@ -112,26 +112,19 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+{%- if cookiecutter.pra -%}
 ### Paperwork Reduction Act
 
-If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
-may apply. It is triggered by collecting standardized information from ten or more members of the
-public within a twelve month period, which includes forms, surveys, and some kinds of user research,
-and it requires OMB clearance before the collection begins rather than after.
+The [Paperwork Reduction Act](https://pra.digital.gov/) applies to this project since it collects information from the public.
 
-See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
-works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+{% endif %}
 
+{%- if cookiecutter.accessibility -%}
 ### Accessibility
 
-This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
-requires that information and communication technology developed, procured, maintained, or used by
-federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
-[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which requires that information and communication technology developed, procured, maintained, or used by federal agencies be accessible to people with disabilities.
 
-Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
-screen reader, as part of normal development rather than as a release gate.
+{% endif %}
 
 ## Public domain
 

--- a/tier4/{{cookiecutter.project_slug}}/README.md
+++ b/tier4/{{cookiecutter.project_slug}}/README.md
@@ -112,6 +112,36 @@ In the spirit of [Executive Order 14028 - Improving the Nation’s Cyber Securit
 
 For more information and resources about SBOMs, visit: https://www.cisa.gov/sbom.
 
+### Paperwork Reduction Act
+
+If this project collects information from the public, the [Paperwork Reduction Act](https://pra.digital.gov/)
+may apply. It is triggered by collecting standardized information from ten or more members of the
+public within a twelve month period, which includes forms, surveys, and some kinds of user research,
+and it requires OMB clearance before the collection begins rather than after.
+
+See [pra.digital.gov](https://pra.digital.gov/) for what counts as a collection and how the review
+works, and talk to your agency's PRA contact early, since clearance takes time to obtain.
+
+### Plain Language
+
+Public-facing content in this project follows the [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/),
+as required by the [Plain Writing Act of 2010](https://www.plainlanguage.gov/law/). The test is
+whether a reader can find what they need, understand it the first time they read it, and use it.
+
+This applies to documentation as much as to interface text. A README is often the first thing a
+member of the public reads about a government project.
+
+### Accessibility
+
+This project follows [Section 508 of the Rehabilitation Act](https://www.section508.gov/), which
+requires that information and communication technology developed, procured, maintained, or used by
+federal agencies be accessible to people with disabilities. The Revised 508 Standards incorporate
+[WCAG 2.0](https://www.w3.org/TR/WCAG20/) Level A and AA by reference, and many teams now target
+[WCAG 2.1](https://www.w3.org/TR/WCAG21/) Level AA.
+
+Automated checkers find only a portion of accessibility defects. Test with a keyboard, and with a
+screen reader, as part of normal development rather than as a release gate.
+
 ## Public domain
 
 This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/) as indicated in [LICENSE](LICENSE).


### PR DESCRIPTION
Closes #39.

## What and why

#39 asked for the policies that shape how federal open source projects get built and released to be represented in the README templates, and named three: [pra.digital.gov](https://pra.digital.gov/), [PlainLanguage.gov](https://www.plainlanguage.gov/), [Section508.gov](https://www.section508.gov/).

None of the five tier templates mentioned any of them. I checked before writing anything: zero occurrences of "508", "plain language", "PRA" or "Paperwork Reduction" across `tier0` through `tier4`. The only near match was the sentence about using accessible language in the community section, which is about capacity building rather than the policy.

Each template already has a `## Policies` section holding **Open Source Policy**, **Security and Responsible Disclosure Policy** and **SBOM**. These three sit alongside those, in the order #39 lists them, added at the end so the existing subsections keep their order and their anchors. Same content in all five tiers, since the obligations do not vary by maturity tier.

## How they are written

The failure mode a template can actually prevent is someone not knowing a policy applies to them, so each section leads with the trigger rather than the citation:

- **Paperwork Reduction Act.** Names the ten-persons-in-twelve-months threshold, notes that some user research counts, and says clearance comes before the collection rather than after. That last point is the one that costs teams time when they learn it late.
- **Plain Language.** Gives the Plain Writing Act as the requirement and states the test as whether a reader can find what they need, understand it first time, and use it. Notes it covers documentation and not only interface text, since a README is often the first thing a member of the public reads about a project.
- **Accessibility.** Cites Section 508, and is deliberately precise that the **Revised 508 Standards incorporate WCAG 2.0 Level A and AA by reference**, while noting many teams now target 2.1 AA. It would be easy to write "follow WCAG 2.1" here, but that overstates the legal baseline, and a template that misstates the standard propagates that into every repo generated from it. Adds that automated checkers find only a portion of defects and that keyboard and screen reader testing belongs in development rather than at a release gate.

I have kept them short and in the voice of the sections already there. Happy to expand any of them, or to cut the practical notes back to bare citations if you would rather these stay purely referential.

## Verification

Rendered all five tiers with cookiecutter using the same context `tests/conftest.py` uses:

| Check | Result |
|---|---|
| `pytest --template tier0` through `tier4` | 5 passed, as CI runs them |
| All three sections present in each generated README | 3 of 3 in all five tiers |
| Unrendered `{{ }}` left in output | 0 in all five tiers |
| All six links | HTTP 200 |

## Notes

- Branched from `dev` per CONTRIBUTING.
- The issue is from 2023, so if the intent has moved on since, say so and I will close this. It looked worth doing rather than leaving open, and it is squarely the kind of thing I care about: I ran Code.gov, so these three policies are the ones I spent years explaining to agencies that had not realised they applied.
