### PR TITLE
Workflows: Specify permissions for various workflows

### DIFF
--- a/.github/workflows/addFilesToRepos.yml
+++ b/.github/workflows/addFilesToRepos.yml
@@ -1,55 +1,58 @@
 name: Add files to repos
 
 on:
-    workflow_dispatch:
-        inputs:
-            query:
-                description: 'Query for github API'
-                default: 'topic:x'
-                required: true
-            org:
-                description: 'Org to search for repos in'
-                default: 'DSACMS'
-                required: true
-            files:
-                description: 'File or folders to add'
-                default: 'tier1/LICENSE'
-                required: true
+  workflow_dispatch:
+    inputs:
+      query:
+        description: "Query for github API"
+        default: "topic:x"
+        required: true
+      org:
+        description: "Org to search for repos in"
+        default: "DSACMS"
+        required: true
+      files:
+        description: "File or folders to add"
+        default: "tier1/LICENSE"
+        required: true
+
+permissions:
+  contents: read
 
 env:
-    repo: ""
+  repo: ""
 
 jobs:
-    find-repos:
-        runs-on: ubuntu-latest
-        name: Find repos and generate matrix
-        steps:
-            - name: Checkout Action
-              uses: actions/checkout@v4
-            - name: Find repos
-              uses: ./.github/findRepos
-              with:
-                query: ${{ github.event.inputs.query }}
-                org: ${{ github.event.inputs.org }}
-                token: ${{ secrets.pat }}
-        outputs:
-            matrix: ${{ env.repo }}
+  find-repos:
+    runs-on: ubuntu-latest
+    name: Find repos and generate matrix
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v4
+      - name: Find repos
+        uses: ./.github/findRepos
+        with:
+          query: ${{ github.event.inputs.query }}
+          org: ${{ github.event.inputs.org }}
+          token: ${{ secrets.pat }}
+    outputs:
+      matrix: ${{ env.repo }}
 
-    add-files:
-        runs-on: ubuntu-latest
-        name: Add files
-        needs: [find-repos]
-        strategy:
-            matrix:
-                repo: ${{ fromJSON(needs.find-repos.outputs.matrix ) }}
-        steps:
-            - name: Checkout Action
-              uses: actions/checkout@v4
-            - name: Update file
-              uses: ./.github/addingFile
-              with:
-                repository: ${{ matrix.repo }}
-                files: ${{ github.event.inputs.files }}
-                token: ${{ secrets.pat }}
-            - name: Checkout Action again to stop post error
-              uses: actions/checkout@v4
+  add-files:
+    runs-on: ubuntu-latest
+    name: Add files
+    needs: [find-repos]
+    strategy:
+      matrix:
+        repo: ${{ fromJSON(needs.find-repos.outputs.matrix ) }}
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v4
+      - name: Update file
+        uses: ./.github/addingFile
+        with:
+          repository: ${{ matrix.repo }}
+          files: ${{ github.event.inputs.files }}
+          token: ${{ secrets.pat }}
+      - name: Checkout Action again to stop post error
+        uses: actions/checkout@v4

--- a/.github/workflows/checklistMarkdownToPDF.yml
+++ b/.github/workflows/checklistMarkdownToPDF.yml
@@ -1,17 +1,19 @@
 name: Converting outbound checklists from .md to .pdf
 on:
-    pull_request:
-        types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
     # Paths can be used to only trigger actions when you have edited checklist files
-        branches:
-        - 'dev'
-        paths:
-        - 'tier*/checklist.md'
+    branches:
+      - "dev"
+    paths:
+      - "tier*/checklist.md"
 
 jobs:
   get-changed-directories:
     name: Get changed directories
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tiers: ${{ steps.list-dirs.outputs.tiers }}
     steps:
@@ -24,7 +26,7 @@ jobs:
         uses: tj-actions/changed-files@v45
         with:
           dir_names: "true"
-          dir_names_include_files: 'checklist.md'
+          dir_names_include_files: "checklist.md"
       - name: List all changed tier directories
         id: list-dirs
         env:
@@ -38,22 +40,22 @@ jobs:
           TIER_DIRS="[$DIRS]"
           echo "$TIER_DIRS"
 
-          echo "tiers=$TIER_DIRS" >> "$GITHUB_OUTPUT" 
+          echo "tiers=$TIER_DIRS" >> "$GITHUB_OUTPUT"
 
   convert-to-pdf:
     name: Build PDF
     runs-on: ubuntu-latest
     needs: get-changed-directories
     permissions:
-        contents: write
+      contents: write
     strategy:
-        max-parallel: 1
-        matrix:
-            tier: ${{ fromJSON(needs.get-changed-directories.outputs.tiers) }}  # List of changed tier directories
+      max-parallel: 1
+      matrix:
+        tier: ${{ fromJSON(needs.get-changed-directories.outputs.tiers) }} # List of changed tier directories
     steps:
       - uses: actions/checkout@v4
         with:
-            ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref }}
       - name: Generate PDF for ${{ matrix.tier }}
         uses: baileyjm02/markdown-to-pdf@v1
         with:

--- a/.github/workflows/extendJSONFile.yml
+++ b/.github/workflows/extendJSONFile.yml
@@ -4,27 +4,30 @@ on:
   workflow_dispatch:
     inputs:
       url_to_json:
-        description: 'URL to JSON file'
-        default: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
+        description: "URL to JSON file"
+        default: "https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json"
         required: true
         type: string
   workflow_call:
     inputs:
       url_to_json:
-        description: 'URL to JSON file'
-        default: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
+        description: "URL to JSON file"
+        default: "https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json"
         required: true
         type: string
     outputs:
-      raw-json: 
-        description: 'JSON of the file'
+      raw-json:
+        description: "JSON of the file"
         value: ${{ jobs.extend-json.outputs.raw-json }}
+
+permissions:
+  contents: read
 
 jobs:
   extend-json:
     runs-on: ubuntu-latest
     name: Extend JSON file with extends property
-    outputs: 
+    outputs:
       raw-json: ${{ steps.extend-json.outputs.raw-json }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/.github/workflows/repoHygieneCheck.yml
+++ b/.github/workflows/repoHygieneCheck.yml
@@ -2,7 +2,7 @@ name: "Repository Hygiene Check"
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
             exit 0
 
           fi
-          
+
           # Check if initialization label exists
 
           has_label=$(gh label list --json name | jq '.[] | select(.name=="repolinter-initialized")')
@@ -45,10 +45,12 @@ jobs:
     name: Get Repolinter Config
     needs: check-first-run
     if: needs.check-first-run.outputs.should_run == 'true'
+    permissions:
+      contents: read
     uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
-    with: 
-      url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'
-  
+    with:
+      url_to_json: "https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json"
+
   repolinter-checks:
     name: Tier 3 Checks
     needs: [check-first-run, resolve-repolinter-json]
@@ -64,7 +66,7 @@ jobs:
       - run: echo $RAW_JSON > repolinter.json
       - uses: DSACMS/repolinter-action@main
         with:
-          config_file: 'repolinter.json'
-          output_type: 'pull-request'
-          pull_request_labels: 'repolinter-initialized, cms-oss, cms-gov'
+          config_file: "repolinter.json"
+          output_type: "pull-request"
+          pull_request_labels: "repolinter-initialized, cms-oss, cms-gov"
           token: ${{ secrets.REPOLINTER_AUTO_TOKEN }}

--- a/.github/workflows/updateStringInRepos.yml
+++ b/.github/workflows/updateStringInRepos.yml
@@ -1,64 +1,67 @@
 name: Update string
 
 on:
-    workflow_dispatch:
-        inputs:
-            query:
-                description: 'Query from github API'
-                default: 'topic:x'
-                required: true
-            org:
-                description: 'Org to search for repos in'
-                default: 'DSACMS'
-                required: true
-            find:
-                description: 'String to search for'
-                default: 'x'
-                required: true
-            replace:
-                description: 'Replacement string'
-                default: 'y'
-                required: true
-            file:
-                description: 'File to replace in'
-                default: 'CONTRIBUTING.md'
+  workflow_dispatch:
+    inputs:
+      query:
+        description: "Query from github API"
+        default: "topic:x"
+        required: true
+      org:
+        description: "Org to search for repos in"
+        default: "DSACMS"
+        required: true
+      find:
+        description: "String to search for"
+        default: "x"
+        required: true
+      replace:
+        description: "Replacement string"
+        default: "y"
+        required: true
+      file:
+        description: "File to replace in"
+        default: "CONTRIBUTING.md"
+
+permissions:
+  contents: read
 
 env:
-    repo: ""
+  repo: ""
 
 jobs:
-    find-repos:
-        runs-on: ubuntu-latest
-        name: Find repos and generate matrix
-        steps:
-            - name: Checkout Action
-              uses: actions/checkout@v4
-            - name: Find repos
-              uses: ./.github/findRepos
-              with:
-                query: ${{ github.event.inputs.query }}
-                org: ${{ github.event.inputs.org }}
-                token: ${{ secrets.pat }}
-        outputs:
-            matrix: ${{ env.repo }}
+  find-repos:
+    runs-on: ubuntu-latest
+    name: Find repos and generate matrix
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v4
+      - name: Find repos
+        uses: ./.github/findRepos
+        with:
+          query: ${{ github.event.inputs.query }}
+          org: ${{ github.event.inputs.org }}
+          token: ${{ secrets.pat }}
+    outputs:
+      matrix: ${{ env.repo }}
 
-    update:
-        runs-on: ubuntu-latest
-        name: Update file
-        needs: [find-repos]
-        strategy:
-            matrix:
-                repo: ${{ fromJSON(needs.find-repos.outputs.matrix ) }}
-        steps:
-            - name: Checkout Action
-              uses: actions/checkout@v4
-            - name: Update file
-              uses: ./.github/fileUpdater
-              with:
-                repository: ${{ matrix.repo }}
-                find: ${{ github.event.inputs.find }}
-                replace: ${{ github.event.inputs.replace }}
-                file: ${{ github.event.inputs.file }}
-                token: ${{ secrets.pat }}
-            - name: Checkout Action again to stop post error
-              uses: actions/checkout@v4
+  update:
+    runs-on: ubuntu-latest
+    name: Update file
+    needs: [find-repos]
+    strategy:
+      matrix:
+        repo: ${{ fromJSON(needs.find-repos.outputs.matrix ) }}
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v4
+      - name: Update file
+        uses: ./.github/fileUpdater
+        with:
+          repository: ${{ matrix.repo }}
+          find: ${{ github.event.inputs.find }}
+          replace: ${{ github.event.inputs.replace }}
+          file: ${{ github.event.inputs.file }}
+          token: ${{ secrets.pat }}
+      - name: Checkout Action again to stop post error
+        uses: actions/checkout@v4

--- a/tier0/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier0/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/tier1/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
+++ b/tier1/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
@@ -49,6 +49,8 @@ jobs:
     {% raw %}
     if: needs.check-first-run.outputs.should_run == 'true'
     {% endraw %}
+    permissions:
+      contents: read
     uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier1/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/tier2/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
+++ b/tier2/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
@@ -49,6 +49,8 @@ jobs:
     {% raw %}
     if: needs.check-first-run.outputs.should_run == 'true'
     {% endraw %}
+    permissions:
+      contents: read
     uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier2/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/tier3/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
+++ b/tier3/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
@@ -49,6 +49,8 @@ jobs:
     {% raw %}
     if: needs.check-first-run.outputs.should_run == 'true'
     {% endraw %}
+    permissions:
+      contents: read
     uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier3/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/gitleaks.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   scan-for-secrets:
     name: Run gitleaks

--- a/tier4/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
+++ b/tier4/{{cookiecutter.project_slug}}/.github/workflows/repoHygieneCheck.yml
@@ -49,6 +49,8 @@ jobs:
     {% raw %}
     if: needs.check-first-run.outputs.should_run == 'true'
     {% endraw %}
+    permissions:
+      contents: read
     uses: DSACMS/repo-scaffolder/.github/workflows/extendJSONFile.yml@main
     with: 
       url_to_json: 'https://raw.githubusercontent.com/DSACMS/repo-scaffolder/main/tier4/%7B%7Bcookiecutter.project_slug%7D%7D/repolinter.json'


### PR DESCRIPTION
## Workflows: Specify permissions for various workflows

## Problem

CodeQL flagged workflow files that do not contain permissions. It is important to have explicit permissions in the workflow to ensure GITHUB_TOKEN and workflow as a whole adhere to the principle of least privilege.

## Solution

Add permissions block to: 
- addFilesToRepos.yml
- checklistMarkdownToPDF.yml
- extendJSON.yml
- updateStringInRepos.yml
- gitleaks.yml - updated across all templates
- repoHygieneCheck.yml - updated across all templates

## AI Usage

- [ ] Generative AI was used in this contribution